### PR TITLE
validate store index

### DIFF
--- a/internal/blockprocessor/committer.go
+++ b/internal/blockprocessor/committer.go
@@ -3,6 +3,8 @@
 package blockprocessor
 
 import (
+	"encoding/json"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/IBM-Blockchain/bcdb-server/internal/blockstore"
@@ -190,8 +192,10 @@ func (c *committer) constructDBAndProvenanceEntries(block *types.Block) ([]*worl
 		}
 
 		tx := block.GetDBAdministrationTxEnvelope().GetPayload()
-		dbsUpdates = []*worldstate.DBUpdates{
-			constructDBEntriesForDBAdminTx(tx, version),
+		var err error
+		dbsUpdates, err = constructDBEntriesForDBAdminTx(tx, version)
+		if err != nil {
+			return nil, nil, errors.WithMessage(err, "error while creating entries for db admin transaction")
 		}
 		c.logger.Debugf("constructed db admin update, block number %d",
 			block.GetHeader().GetBaseHeader().GetNumber())
@@ -275,12 +279,26 @@ func constructDBEntriesForDataTx(tx *types.DataTx, version *types.Version) []*wo
 	return dbsUpdates
 }
 
-func constructDBEntriesForDBAdminTx(tx *types.DBAdministrationTx, version *types.Version) *worldstate.DBUpdates {
+func constructDBEntriesForDBAdminTx(tx *types.DBAdministrationTx, version *types.Version) ([]*worldstate.DBUpdates, error) {
 	var toCreateDBs []*worldstate.KVWithMetadata
+	var indexForExistingDBs []*worldstate.KVWithMetadata
 
 	for _, dbName := range tx.CreateDBs {
+		var value []byte
+		dbIndex, ok := tx.DBsIndex[dbName]
+		if ok {
+			v, err := json.Marshal(dbIndex.AttributeAndType)
+			if err != nil {
+				return nil, errors.Wrap(err, "error while marshaling index for database ["+dbName+"]")
+			}
+			value = v
+
+			delete(tx.DBsIndex, dbName)
+		}
+
 		db := &worldstate.KVWithMetadata{
-			Key: dbName,
+			Key:   dbName,
+			Value: value,
 			Metadata: &types.Metadata{
 				Version: version,
 			},
@@ -288,11 +306,37 @@ func constructDBEntriesForDBAdminTx(tx *types.DBAdministrationTx, version *types
 		toCreateDBs = append(toCreateDBs, db)
 	}
 
-	return &worldstate.DBUpdates{
-		DBName:  worldstate.DatabasesDBName,
-		Writes:  toCreateDBs,
-		Deletes: tx.DeleteDBs,
+	for dbName, dbIndex := range tx.DBsIndex {
+		var value []byte
+		if dbIndex != nil && dbIndex.GetAttributeAndType() != nil {
+			v, err := json.Marshal(dbIndex.GetAttributeAndType())
+			if err != nil {
+				return nil, errors.Wrap(err, "error while marshaling index for database ["+dbName+"]")
+			}
+			value = v
+		}
+
+		db := &worldstate.KVWithMetadata{
+			Key:   dbName,
+			Value: value,
+			Metadata: &types.Metadata{
+				Version: version,
+			},
+		}
+		indexForExistingDBs = append(indexForExistingDBs, db)
 	}
+
+	return []*worldstate.DBUpdates{
+		{
+			DBName:  worldstate.DatabasesDBName,
+			Writes:  toCreateDBs,
+			Deletes: tx.DeleteDBs,
+		},
+		{
+			DBName: worldstate.DatabasesDBName,
+			Writes: indexForExistingDBs,
+		},
+	}, nil
 }
 
 type dbEntriesForConfigTx struct {

--- a/internal/blockprocessor/dbadmin_tx_validator.go
+++ b/internal/blockprocessor/dbadmin_tx_validator.go
@@ -39,7 +39,11 @@ func (v *dbAdminTxValidator) validate(txEnv *types.DBAdministrationTxEnvelope) (
 		return r, nil
 	}
 
-	return v.validateDeleteDBEntries(tx.DeleteDBs), nil
+	if r := v.validateDeleteDBEntries(tx.DeleteDBs); r.Flag != types.Flag_VALID {
+		return r, nil
+	}
+
+	return v.validateIndexEntries(tx.DBsIndex, tx.CreateDBs, tx.DeleteDBs), nil
 }
 
 func (v *dbAdminTxValidator) validateCreateDBEntries(toCreateDBs []string) *types.ValidationInfo {
@@ -107,6 +111,7 @@ func (v *dbAdminTxValidator) validateDeleteDBEntries(toDeleteDBs []string) *type
 			}
 
 		case !v.db.ValidDBName(dbName):
+			v.logger.Debug("invalid db name")
 			return &types.ValidationInfo{
 				Flag:            types.Flag_INVALID_INCORRECT_ENTRIES,
 				ReasonIfInvalid: "the database name [" + dbName + "] is not valid",
@@ -140,6 +145,51 @@ func (v *dbAdminTxValidator) validateDeleteDBEntries(toDeleteDBs []string) *type
 			}
 
 			toDeleteDBsLookup[dbName] = true
+		}
+	}
+
+	return &types.ValidationInfo{
+		Flag: types.Flag_VALID,
+	}
+}
+
+func (v *dbAdminTxValidator) validateIndexEntries(dbsIndex map[string]*types.DBIndex, toCreateDBs, toDeleteDBs []string) *types.ValidationInfo {
+	toCreateDBsLookup := make(map[string]bool)
+	toDeleteDBsLookup := make(map[string]bool)
+
+	for _, dbName := range toCreateDBs {
+		toCreateDBsLookup[dbName] = true
+	}
+	for _, dbName := range toDeleteDBs {
+		toDeleteDBsLookup[dbName] = true
+	}
+
+	for dbName, dbIndex := range dbsIndex {
+		if !v.db.Exist(dbName) && !toCreateDBsLookup[dbName] {
+			return &types.ValidationInfo{
+				Flag:            types.Flag_INVALID_INCORRECT_ENTRIES,
+				ReasonIfInvalid: "index definion provided for database [" + dbName + "] cannot be processed as the database neither exist nor in the create DB list",
+			}
+		}
+
+		if v.db.Exist(dbName) && toDeleteDBsLookup[dbName] {
+			return &types.ValidationInfo{
+				Flag:            types.Flag_INVALID_INCORRECT_ENTRIES,
+				ReasonIfInvalid: "index definion provided for database [" + dbName + "] cannot be processed as the database is present in the delete list",
+			}
+		}
+
+		for attr, ty := range dbIndex.AttributeAndType {
+			switch ty {
+			case types.Type_NUMBER:
+			case types.Type_STRING:
+			case types.Type_BOOLEAN:
+			default:
+				return &types.ValidationInfo{
+					Flag:            types.Flag_INVALID_INCORRECT_ENTRIES,
+					ReasonIfInvalid: "invalid type provided for the attribute [" + attr + "]",
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit validates DB index defined for the database. An index
for a database can be defined or updated for an existing database and
also can be defined when the db is created
