### PR TITLE
validate and commit index definition

### DIFF
--- a/internal/blockprocessor/committer_test.go
+++ b/internal/blockprocessor/committer_test.go
@@ -3,6 +3,7 @@
 package blockprocessor
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -848,6 +849,7 @@ func TestStateDBCommitterForDBBlock(t *testing.T) {
 		expectedDBsBefore []string
 		dbAdminTx         *types.DBAdministrationTx
 		expectedDBsAfter  []string
+		expectedIndex     map[string]*types.DBIndex
 		valInfo           []*types.ValidationInfo
 	}{
 		{
@@ -873,8 +875,113 @@ func TestStateDBCommitterForDBBlock(t *testing.T) {
 			dbAdminTx: &types.DBAdministrationTx{
 				CreateDBs: []string{"db3", "db4"},
 				DeleteDBs: []string{"db1", "db2"},
+				DBsIndex: map[string]*types.DBIndex{
+					"db3": {
+						AttributeAndType: map[string]types.Type{
+							"attr1": types.Type_BOOLEAN,
+							"attr2": types.Type_NUMBER,
+						},
+					},
+				},
 			},
 			expectedDBsAfter: []string{"db3", "db4"},
+			expectedIndex: map[string]*types.DBIndex{
+				"db3": {
+					AttributeAndType: map[string]types.Type{
+						"attr1": types.Type_BOOLEAN,
+						"attr2": types.Type_NUMBER,
+					},
+				},
+				"db4": nil,
+			},
+			valInfo: []*types.ValidationInfo{
+				{
+					Flag: types.Flag_VALID,
+				},
+			},
+		},
+		{
+			name: "change index of an existing DB and create index for new DB",
+			setup: func(db worldstate.DB) {
+				indexDB1, err := json.Marshal(
+					map[string]types.Type{
+						"attr1-db1": types.Type_NUMBER,
+						"attr2-db1": types.Type_BOOLEAN,
+						"attr3-db1": types.Type_STRING,
+					},
+				)
+				require.NoError(t, err)
+
+				indexDB2, err := json.Marshal(
+					map[string]types.Type{
+						"attr1-db2": types.Type_NUMBER,
+						"attr2-db2": types.Type_BOOLEAN,
+						"attr3-db2": types.Type_STRING,
+					},
+				)
+				require.NoError(t, err)
+
+				createDBs := []*worldstate.DBUpdates{
+					{
+						DBName: worldstate.DatabasesDBName,
+						Writes: []*worldstate.KVWithMetadata{
+							{
+								Key:   "db1",
+								Value: indexDB1,
+							},
+							{
+								Key:   "db2",
+								Value: indexDB2,
+							},
+						},
+					},
+				}
+
+				require.NoError(t, db.Commit(createDBs, 1))
+			},
+			expectedDBsBefore: []string{"db1", "db2"},
+			dbAdminTx: &types.DBAdministrationTx{
+				CreateDBs: []string{"db3", "db4"},
+				DBsIndex: map[string]*types.DBIndex{
+					"db1": {
+						AttributeAndType: map[string]types.Type{
+							"attr1": types.Type_BOOLEAN,
+							"attr2": types.Type_NUMBER,
+						},
+					},
+					"db2": nil,
+					"db3": {
+						AttributeAndType: map[string]types.Type{
+							"attr1": types.Type_STRING,
+						},
+					},
+					"db4": {
+						AttributeAndType: map[string]types.Type{
+							"attr1": types.Type_NUMBER,
+						},
+					},
+				},
+			},
+			expectedDBsAfter: []string{"db1", "db2", "db3", "db4"},
+			expectedIndex: map[string]*types.DBIndex{
+				"db1": {
+					AttributeAndType: map[string]types.Type{
+						"attr1": types.Type_BOOLEAN,
+						"attr2": types.Type_NUMBER,
+					},
+				},
+				"db2": nil,
+				"db3": {
+					AttributeAndType: map[string]types.Type{
+						"attr1": types.Type_STRING,
+					},
+				},
+				"db4": {
+					AttributeAndType: map[string]types.Type{
+						"attr1": types.Type_NUMBER,
+					},
+				},
+			},
 			valInfo: []*types.ValidationInfo{
 				{
 					Flag: types.Flag_VALID,
@@ -905,6 +1012,10 @@ func TestStateDBCommitterForDBBlock(t *testing.T) {
 				DeleteDBs: []string{"db1", "db2"},
 			},
 			expectedDBsAfter: []string{"db1", "db2"},
+			expectedIndex: map[string]*types.DBIndex{
+				"db1": nil,
+				"db2": nil,
+			},
 			valInfo: []*types.ValidationInfo{
 				{
 					Flag: types.Flag_INVALID_NO_PERMISSION,
@@ -947,6 +1058,15 @@ func TestStateDBCommitterForDBBlock(t *testing.T) {
 
 			for _, dbName := range tt.expectedDBsAfter {
 				require.True(t, env.db.Exist(dbName))
+				index, _, err := env.db.Get(worldstate.DatabasesDBName, dbName)
+				require.NoError(t, err)
+
+				var expectedIndex []byte
+				if tt.expectedIndex[dbName] != nil {
+					expectedIndex, err = json.Marshal(tt.expectedIndex[dbName].GetAttributeAndType())
+				}
+				require.NoError(t, err)
+				require.Equal(t, expectedIndex, index)
 			}
 		})
 	}

--- a/internal/blockprocessor/dbadmin_tx_validator_test.go
+++ b/internal/blockprocessor/dbadmin_tx_validator_test.go
@@ -5,12 +5,12 @@ package blockprocessor
 import (
 	"testing"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/stretchr/testify/require"
 	"github.com/IBM-Blockchain/bcdb-server/internal/identity"
 	"github.com/IBM-Blockchain/bcdb-server/internal/worldstate"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/server/testutils"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateDBAdminTx(t *testing.T) {
@@ -165,6 +165,26 @@ func TestValidateDBAdminTx(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid: db does not exist already and also does not appear in the createDB list",
+			setup: func(db worldstate.DB) {
+				require.NoError(t, db.Commit(privilegedUser, 1))
+			},
+			txEnv: testutils.SignedDBAdministrationTxEnvelope(t, adminSigner, &types.DBAdministrationTx{
+				UserID: "userWithMorePrivilege",
+				DBsIndex: map[string]*types.DBIndex{
+					"db1": {
+						AttributeAndType: map[string]types.Type{
+							"attr1": types.Type_STRING,
+						},
+					},
+				},
+			}),
+			expectedResult: &types.ValidationInfo{
+				Flag:            types.Flag_INVALID_INCORRECT_ENTRIES,
+				ReasonIfInvalid: "index definion provided for database [db1] cannot be processed as the database neither exists nor is in the create DB list",
+			},
+		},
+		{
 			name: "valid transaction",
 			setup: func(db worldstate.DB) {
 				require.NoError(t, db.Commit(privilegedUser, 1))
@@ -188,6 +208,13 @@ func TestValidateDBAdminTx(t *testing.T) {
 				UserID:    "userWithMorePrivilege",
 				CreateDBs: []string{"db1", "db2"},
 				DeleteDBs: []string{"db3", "db4"},
+				DBsIndex: map[string]*types.DBIndex{
+					"db1": {
+						AttributeAndType: map[string]types.Type{
+							"attr1": types.Type_STRING,
+						},
+					},
+				},
 			}),
 			expectedResult: &types.ValidationInfo{
 				Flag: types.Flag_VALID,
@@ -399,6 +426,114 @@ func TestValidateDeleteDBEntries(t *testing.T) {
 			}
 
 			result := env.validator.dbAdminTxValidator.validateDeleteDBEntries(tt.toDeleteDBs)
+			require.True(t, proto.Equal(tt.expectedResult, result))
+		})
+	}
+}
+
+func TestValidateIndexDBEntries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		setup          func(db worldstate.DB)
+		toCreateDBs    []string
+		toDeleteDBs    []string
+		dbsIndex       map[string]*types.DBIndex
+		expectedResult *types.ValidationInfo
+	}{
+		{
+			name: "invalid: db does not exist already and also does not appear in the createDB list",
+			dbsIndex: map[string]*types.DBIndex{
+				"db1": {
+					AttributeAndType: map[string]types.Type{
+						"attr1": types.Type_STRING,
+					},
+				},
+			},
+			expectedResult: &types.ValidationInfo{
+				Flag:            types.Flag_INVALID_INCORRECT_ENTRIES,
+				ReasonIfInvalid: "index definion provided for database [db1] cannot be processed as the database neither exists nor is in the create DB list",
+			},
+		},
+		{
+			name:        "valid: db does not exist already but appears in the createDB list",
+			toCreateDBs: []string{"db1"},
+			dbsIndex: map[string]*types.DBIndex{
+				"db1": {
+					AttributeAndType: map[string]types.Type{
+						"attr1": types.Type_STRING,
+						"attr2": types.Type_NUMBER,
+						"attr3": types.Type_BOOLEAN,
+					},
+				},
+			},
+			expectedResult: &types.ValidationInfo{
+				Flag: types.Flag_VALID,
+			},
+		},
+		{
+			name: "invalid: db exist but appears in the deleteDB list too",
+			setup: func(db worldstate.DB) {
+				createDB := []*worldstate.DBUpdates{
+					{
+						DBName: worldstate.DatabasesDBName,
+						Writes: []*worldstate.KVWithMetadata{
+							{
+								Key: "db1",
+							},
+							{
+								Key: "db2",
+							},
+						},
+					},
+				}
+				require.NoError(t, db.Commit(createDB, 1))
+			},
+			toDeleteDBs: []string{"db1", "db2"},
+			dbsIndex: map[string]*types.DBIndex{
+				"db1": {
+					AttributeAndType: map[string]types.Type{
+						"attr1": types.Type_STRING,
+					},
+				},
+			},
+			expectedResult: &types.ValidationInfo{
+				Flag:            types.Flag_INVALID_INCORRECT_ENTRIES,
+				ReasonIfInvalid: "index definion provided for database [db1] cannot be processed as the database is present in the delete list",
+			},
+		},
+		{
+			name:        "invalid: unknown attribute type",
+			toCreateDBs: []string{"db1"},
+			dbsIndex: map[string]*types.DBIndex{
+				"db1": {
+					AttributeAndType: map[string]types.Type{
+						"attr1": types.Type_STRING,
+						"attr2": types.Type_NUMBER,
+						"attr3": 10,
+					},
+				},
+			},
+			expectedResult: &types.ValidationInfo{
+				Flag:            types.Flag_INVALID_INCORRECT_ENTRIES,
+				ReasonIfInvalid: "invalid type provided for the attribute [attr3]",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := newValidatorTestEnv(t)
+			defer env.cleanup()
+			if tt.setup != nil {
+				tt.setup(env.db)
+			}
+
+			result := env.validator.dbAdminTxValidator.validateIndexEntries(tt.dbsIndex, tt.toCreateDBs, tt.toDeleteDBs)
 			require.True(t, proto.Equal(tt.expectedResult, result))
 		})
 	}


### PR DESCRIPTION
This commit validates DB index defined for the database. An index
for a database can be defined or updated for an existing database and
also can be defined when the db is created

Signed-off-by: senthil <snatara7@in.ibm.com>