### PR TITLE
Order preserving encoding of +ve/-ve value of indexed attribute

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/cayleygraph/cayley v0.7.7
 	github.com/cayleygraph/quad v1.1.0
+	github.com/gogo/protobuf v1.3.0
 	github.com/golang/protobuf v1.4.2
 	github.com/golang/snappy v0.0.1
 	github.com/google/uuid v1.1.1

--- a/internal/stateindex/encoding.go
+++ b/internal/stateindex/encoding.go
@@ -1,0 +1,83 @@
+package stateindex
+
+import (
+	"math"
+)
+
+// encodeOrderPreservingVarUint64 returns a byte-representation for a uint64 number such that
+// all zero-bits starting bytes are trimmed in order to reduce the length of the array
+// For preserving the order in a default bytes-comparison, first byte contains the number of remaining bytes.
+func encodeOrderPreservingVarUint64(n uint64) []byte {
+	var bytePosition int
+	for bytePosition = 0; bytePosition <= 7; bytePosition++ {
+		if byte(n>>(56-(bytePosition*8))) != 0x00 {
+			break
+		}
+	}
+
+	size := int8(8 - bytePosition)
+	encodedBytes := make([]byte, size+1)
+	encodedBytes[0] = byte(size)
+	p := 1
+	for r := bytePosition; r <= 7; r++ {
+		encodedBytes[p] = byte(n >> (56 - (r * 8)))
+		p++
+	}
+	return encodedBytes
+}
+
+// decodeOrderPreservingVarUint64 decodes the number from the bytes obtained from method 'encodeOrderPreservingVarUint64'.
+// It returns the decoded number.
+func decodeOrderPreservingVarUint64(b []byte) uint64 {
+	size := int(b[0])
+	var v uint64
+	for i := 7; i >= 8-size; i-- {
+		v = v | uint64(b[size-(7-i)])<<(56-(i*8))
+	}
+	return v
+}
+
+// encodeReverseOrderVarUint64 returns a byte-representation for a uint64 number such that
+// the number is first subtracted from MaxUint64 and then all the leading 0xff bytes
+// are trimmed and replaced by the number of such trimmed bytes. This helps in reducing the size.
+// In the byte order comparison this encoding ensures that encodeReverseOrderVarUint64(A) > encodeReverseOrderVarUint64(B),
+// If B > A
+func encodeReverseOrderVarUint64(n uint64) []byte {
+	n = math.MaxUint64 - n
+
+	var bytePosition int
+	for bytePosition = 0; bytePosition <= 7; bytePosition++ {
+		if byte(n>>(56-(bytePosition*8))) != 0xff {
+			break
+		}
+	}
+
+	size := int8(8 - bytePosition)
+	encodedBytes := make([]byte, size+1)
+	encodedBytes[0] = byte(bytePosition)
+	p := 1
+	for r := bytePosition; r <= 7; r++ {
+		encodedBytes[p] = byte(n >> (56 - (r * 8)))
+		p++
+	}
+	return encodedBytes
+}
+
+// decodeReverseOrderVarUint64 decodes the number from the bytes obtained from function 'encodeReverseOrderVarUint64'.
+func decodeReverseOrderVarUint64(b []byte) uint64 {
+	bytePosition := int(b[0])
+
+	size := 8 - bytePosition
+
+	var v uint64
+	var i int
+	for i = 7; i >= 8-size; i-- {
+		v = v | uint64(b[size-(7-i)])<<(56-(i*8))
+	}
+
+	for j := i; j >= 0; j-- {
+		v = v | uint64(0xff)<<(56-(j*8))
+	}
+
+	return math.MaxUint64 - v
+}

--- a/internal/stateindex/encoding_test.go
+++ b/internal/stateindex/encoding_test.go
@@ -1,0 +1,47 @@
+package stateindex
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+func TestOrderPreservingEncodingDecoding(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		testEncodeAndDecode(t, uint64(i))
+	}
+	testEncodeAndDecode(t, math.MaxUint64-1)
+}
+
+func testEncodeAndDecode(t *testing.T, n uint64) {
+	value := encodeOrderPreservingVarUint64(n)
+	nextValue := encodeOrderPreservingVarUint64(n + 1)
+	if !(bytes.Compare(value, nextValue) < 0) {
+		t.Fatalf("A smaller integer should result into smaller bytes. Encoded bytes for [%d] is [%x] and for [%d] is [%x]",
+			n, n+1, value, nextValue)
+	}
+	decodedValue := decodeOrderPreservingVarUint64(value)
+	if decodedValue != n {
+		t.Fatalf("Value not same after decoding. Original value = [%d], decode value = [%d]", n, decodedValue)
+	}
+}
+
+func TestReverseOrderPreservingEncodingDecoding(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		testReverseOrderEncodingAndDecoding(t, uint64(i))
+	}
+	testReverseOrderEncodingAndDecoding(t, math.MaxUint64-1)
+}
+
+func testReverseOrderEncodingAndDecoding(t *testing.T, n uint64) {
+	value := encodeReverseOrderVarUint64(n)
+	nextValue := encodeReverseOrderVarUint64(n + 1)
+	if !(bytes.Compare(value, nextValue) > 0) {
+		t.Fatalf("A smaller integer should result into greater bytes. Encoded bytes for [%d] is [%x] and for [%d] is [%x]",
+			n, n+1, value, nextValue)
+	}
+	decodedValue := decodeReverseOrderVarUint64(value)
+	if decodedValue != n {
+		t.Fatalf("Value not same after decoding. Original value = [%d], decode value = [%d]", n, decodedValue)
+	}
+}

--- a/internal/stateindex/index_entries_test.go
+++ b/internal/stateindex/index_entries_test.go
@@ -4,8 +4,10 @@ package stateindex
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"io/ioutil"
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -79,6 +81,7 @@ func TestConstructIndexEntries(t *testing.T) {
 	indexDB2Json, err := json.Marshal(indexDB2)
 	require.NoError(t, err)
 
+	encoded10 := base64.URLEncoding.EncodeToString(encodeOrderPreservingVarUint64(uint64(10)))
 	createDBsWithIndex := map[string]*worldstate.DBUpdates{
 		worldstate.DatabasesDBName: {
 			Writes: []*worldstate.KVWithMetadata{
@@ -189,20 +192,20 @@ func TestConstructIndexEntries(t *testing.T) {
 				IndexDBPrefix + "db1": {
 					Writes: []*worldstate.KVWithMetadata{
 						{
-							Key: `{"a":"a1","t":0,"v":"10","k":"person1"}`,
+							Key: `{"a":"a1","t":0,"m":"` + PositiveNumber + `","v":"` + encoded10 + `","k":"person1"}`,
 						},
 						{
-							Key: `{"a":"a2","t":1,"v":"ten","k":"person1"}`,
+							Key: `{"a":"a2","t":1,"m":"","v":"ten","k":"person1"}`,
 						},
 						{
-							Key: `{"a":"a3","t":2,"v":true,"k":"person1"}`,
+							Key: `{"a":"a3","t":2,"m":"","v":true,"k":"person1"}`,
 						},
 					},
 				},
 				IndexDBPrefix + "db2": {
 					Writes: []*worldstate.KVWithMetadata{
 						{
-							Key: `{"a":"a2","t":1,"v":"eleven","k":"person2"}`,
+							Key: `{"a":"a2","t":1,"m":"","v":"eleven","k":"person2"}`,
 						},
 					},
 				},
@@ -254,25 +257,25 @@ func TestConstructIndexEntries(t *testing.T) {
 				IndexDBPrefix + "db1": {
 					Writes: []*worldstate.KVWithMetadata{
 						{
-							Key: `{"a":"a3","t":2,"v":true,"k":"person1"}`,
+							Key: `{"a":"a3","t":2,"m":"","v":true,"k":"person1"}`,
 						},
 						{
-							Key: `{"a":"a2","t":1,"v":"10","k":"person1"}`,
+							Key: `{"a":"a2","t":1,"m":"","v":"10","k":"person1"}`,
 						},
 					},
 					Deletes: []string{
-						`{"a":"a3","t":2,"v":false,"k":"person1"}`,
-						`{"a":"a2","t":1,"v":"ten","k":"person1"}`,
+						`{"a":"a3","t":2,"m":"","v":false,"k":"person1"}`,
+						`{"a":"a2","t":1,"m":"","v":"ten","k":"person1"}`,
 					},
 				},
 				IndexDBPrefix + "db2": {
 					Writes: []*worldstate.KVWithMetadata{
 						{
-							Key: `{"a":"a2","t":1,"v":"eleven","k":"person2"}`,
+							Key: `{"a":"a2","t":1,"m":"","v":"eleven","k":"person2"}`,
 						},
 					},
 					Deletes: []string{
-						`{"a":"a2","t":1,"v":"ten","k":"person2"}`,
+						`{"a":"a2","t":1,"m":"","v":"ten","k":"person2"}`,
 					},
 				},
 			},
@@ -312,14 +315,14 @@ func TestConstructIndexEntries(t *testing.T) {
 			expectedIndexEntries: map[string]*worldstate.DBUpdates{
 				IndexDBPrefix + "db1": {
 					Deletes: []string{
-						`{"a":"a1","t":0,"v":"10","k":"person1"}`,
-						`{"a":"a2","t":1,"v":"ten","k":"person1"}`,
-						`{"a":"a3","t":2,"v":true,"k":"person1"}`,
+						`{"a":"a1","t":0,"m":"` + PositiveNumber + `","v":"` + encoded10 + `","k":"person1"}`,
+						`{"a":"a2","t":1,"m":"","v":"ten","k":"person1"}`,
+						`{"a":"a3","t":2,"m":"","v":true,"k":"person1"}`,
 					},
 				},
 				IndexDBPrefix + "db2": {
 					Deletes: []string{
-						`{"a":"a2","t":1,"v":"eleven","k":"person2"}`,
+						`{"a":"a2","t":1,"m":"","v":"eleven","k":"person2"}`,
 					},
 				},
 			},
@@ -345,6 +348,9 @@ func TestIndexEntriesForNewValues(t *testing.T) {
 	indexDef := map[string]types.Type{
 		"age": types.Type_NUMBER,
 	}
+
+	encoded25 := encodeOrderPreservingVarUint64(uint64(25))
+	encoded26 := encodeOrderPreservingVarUint64(uint64(26))
 
 	testCases := []struct {
 		name                 string
@@ -395,13 +401,15 @@ func TestIndexEntriesForNewValues(t *testing.T) {
 				{
 					Attribute: "age",
 					Type:      types.Type_NUMBER,
-					Value:     "25",
+					Metadata:  PositiveNumber,
+					Value:     encoded25,
 					Key:       "person1",
 				},
 				{
 					Attribute: "age",
 					Type:      types.Type_NUMBER,
-					Value:     "26",
+					Metadata:  PositiveNumber,
+					Value:     encoded26,
 					Key:       "person2",
 				},
 			},
@@ -421,6 +429,11 @@ func TestIndexEntriesOfExistingValues(t *testing.T) {
 	indexDef := map[string]types.Type{
 		"age": types.Type_NUMBER,
 	}
+
+	encoded25 := encodeOrderPreservingVarUint64(uint64(25))
+	encodedNegative26 := encodeReverseOrderVarUint64(uint64(26))
+	encoded0 := encodeOrderPreservingVarUint64(uint64(0))
+	encodedMax := encodeOrderPreservingVarUint64(math.MaxInt64)
 
 	testCases := []struct {
 		name                 string
@@ -487,7 +500,15 @@ func TestIndexEntriesOfExistingValues(t *testing.T) {
 							},
 							{
 								Key:   "person2",
-								Value: []byte(`{"age": 26}`),
+								Value: []byte(`{"age": -26}`),
+							},
+							{
+								Key:   "person3",
+								Value: []byte(`{"age": 0}`),
+							},
+							{
+								Key:   "person4",
+								Value: []byte(`{"age": 9223372036854775807}`),
 							},
 						},
 					},
@@ -495,19 +516,35 @@ func TestIndexEntriesOfExistingValues(t *testing.T) {
 				require.NoError(t, db.Commit(updates, 1))
 			},
 			dbName:      worldstate.DefaultDBName,
-			deletedKeys: []string{"person1", "person2"},
+			deletedKeys: []string{"person1", "person2", "person3", "person4"},
 			expectedIndexEntries: []*indexEntry{
 				{
 					Attribute: "age",
 					Type:      types.Type_NUMBER,
-					Value:     "25",
+					Metadata:  PositiveNumber,
+					Value:     encoded25,
 					Key:       "person1",
 				},
 				{
 					Attribute: "age",
 					Type:      types.Type_NUMBER,
-					Value:     "26",
+					Metadata:  NegativeNumber,
+					Value:     encodedNegative26,
 					Key:       "person2",
+				},
+				{
+					Attribute: "age",
+					Type:      types.Type_NUMBER,
+					Metadata:  PositiveNumber,
+					Value:     encoded0,
+					Key:       "person3",
+				},
+				{
+					Attribute: "age",
+					Type:      types.Type_NUMBER,
+					Metadata:  PositiveNumber,
+					Value:     encodedMax,
+					Key:       "person4",
 				},
 			},
 		},
@@ -525,12 +562,14 @@ func TestIndexEntriesOfExistingValues(t *testing.T) {
 }
 
 func TestPartialIndexEntriesForValue(t *testing.T) {
+	encoded10 := encodeOrderPreservingVarUint64(uint64(10))
 	expectedIndexEntries :=
 		[]*indexEntry{
 			{
 				Attribute: "a1",
 				Type:      types.Type_NUMBER,
-				Value:     "10",
+				Metadata:  PositiveNumber,
+				Value:     encoded10,
 			},
 			{
 				Attribute: "a2",
@@ -579,7 +618,8 @@ func TestPartialIndexEntriesForValue(t *testing.T) {
 					 "first3":{
 					 	"a3":true,
 						"a5": 11,
-						"a2": [1, 2, 3, 4]
+						"a2": [1, 2, 3, 4],
+						"a1": 10.3
 					 },
 					 "a4":"engineer"
 				}`,
@@ -609,7 +649,8 @@ func TestPartialIndexEntriesForValue(t *testing.T) {
 						"second3" : {
 							"a3": true
 						},
-						"a5": 11
+						"a5": 11,
+						"a1": 23.564
 					 },
 					 "a4":"engineer"
 				}`,


### PR DESCRIPTION
When the indexed attribute value is a number, it can be
either a positive number or a negative number. Further, we
need to store these numbers in the indexDB while preserving
the order (i.e., 1 < 5) which is needed for performing range query
on the indexed attributes.

Hence, this commit identifies whether the value of an index attribute
is +ve or -ve and accordingly encoding them to preserve the order.