### PR TITLE
rename .bin to bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ COVERAGE_MODE    = atomic
 COVERAGE_PROFILE = $(COVERAGE_DIR)/profile.out
 COVERAGE_XML     = $(COVERAGE_DIR)/coverage.xml
 COVERAGE_HTML    = $(COVERAGE_DIR)/index.html
-BIN = $(CURDIR)/.bin
+BIN = $(CURDIR)/bin
 
 $(BIN):
 	@mkdir -p $@

--- a/test/setup/cluster_setup_test.go
+++ b/test/setup/cluster_setup_test.go
@@ -18,7 +18,7 @@ func TestCluster(t *testing.T) {
 	setupConfig := &setup.Config{
 		NumberOfServers:     3,
 		TestDirAbsolutePath: dir,
-		BDBBinaryPath:       "../../.bin/bdb",
+		BDBBinaryPath:       "../../bin/bdb",
 		CmdTimeout:          10 * time.Second,
 	}
 	c, err := setup.NewCluster(setupConfig)


### PR DESCRIPTION
Once we run `make binary`, it is quite non-intuitive
to not see the binary on the `ls` output. Hence, it would
be better to unhide the .bin directory.

Signed-off-by: senthil <cendhu@gmail.com>