### PR TITLE
Integrate raft node

### DIFF
--- a/internal/bcdb/db.go
+++ b/internal/bcdb/db.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	ierrors "github.com/IBM-Blockchain/bcdb-server/internal/errors"
 	"io/ioutil"
 	"time"
 
@@ -32,6 +33,9 @@ type DB interface {
 
 	// Height returns ledger height
 	Height() (uint64, error)
+
+	// IsLeader returns whether the this server is the leader
+	IsLeader() *ierrors.NotLeaderError
 
 	// DoesUserExist checks whenever user with given userID exists
 	DoesUserExist(userID string) (bool, error)
@@ -258,6 +262,11 @@ func (d *db) LedgerHeight() (uint64, error) {
 // Height returns ledger height
 func (d *db) Height() (uint64, error) {
 	return d.worldstateQueryProcessor.db.Height()
+}
+
+// IsLeader returns whether the current node is a leader
+func (d *db) IsLeader() *ierrors.NotLeaderError {
+	return d.txProcessor.IsLeader()
 }
 
 // DoesUserExist checks whenever userID exists

--- a/internal/bcdb/mocks/db.go
+++ b/internal/bcdb/mocks/db.go
@@ -3,9 +3,10 @@
 package mocks
 
 import (
-	time "time"
-
+	errors "github.com/IBM-Blockchain/bcdb-server/internal/errors"
 	mock "github.com/stretchr/testify/mock"
+
+	time "time"
 
 	types "github.com/IBM-Blockchain/bcdb-server/pkg/types"
 
@@ -611,6 +612,22 @@ func (_m *DB) IsDBExists(name string) bool {
 		r0 = rf(name)
 	} else {
 		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// IsLeader provides a mock function with given fields:
+func (_m *DB) IsLeader() *errors.NotLeaderError {
+	ret := _m.Called()
+
+	var r0 *errors.NotLeaderError
+	if rf, ok := ret.Get(0).(func() *errors.NotLeaderError); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*errors.NotLeaderError)
+		}
 	}
 
 	return r0

--- a/internal/blockcreator/blockcreator.go
+++ b/internal/blockcreator/blockcreator.go
@@ -15,7 +15,7 @@ import (
 
 // Replicator is the input to the block replication layer.
 type Replicator interface {
-	Submit(block interface{}) error
+	Submit(block *types.Block) error
 }
 
 // BlockCreator uses transactions batch queue to construct the

--- a/internal/blockcreator/blockcreator_test.go
+++ b/internal/blockcreator/blockcreator_test.go
@@ -84,7 +84,7 @@ func newTestEnv(t *testing.T) *testEnv {
 	blockQueue := queue.New(10) // Output: accumulates the blocks that are submitted to the Replicator.
 	mockReplicator := &mocks.Replicator{}
 	mockReplicator.SubmitCalls(
-		func(block interface{}) error {
+		func(block *types.Block) error {
 			blockQueue.Enqueue(block)
 			return nil
 		},

--- a/internal/blockcreator/mocks/replicator.go
+++ b/internal/blockcreator/mocks/replicator.go
@@ -5,13 +5,14 @@ import (
 	"sync"
 
 	"github.com/IBM-Blockchain/bcdb-server/internal/blockcreator"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
 )
 
 type Replicator struct {
-	SubmitStub        func(interface{}) error
+	SubmitStub        func(*types.Block) error
 	submitMutex       sync.RWMutex
 	submitArgsForCall []struct {
-		arg1 interface{}
+		arg1 *types.Block
 	}
 	submitReturns struct {
 		result1 error
@@ -23,11 +24,11 @@ type Replicator struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Replicator) Submit(arg1 interface{}) error {
+func (fake *Replicator) Submit(arg1 *types.Block) error {
 	fake.submitMutex.Lock()
 	ret, specificReturn := fake.submitReturnsOnCall[len(fake.submitArgsForCall)]
 	fake.submitArgsForCall = append(fake.submitArgsForCall, struct {
-		arg1 interface{}
+		arg1 *types.Block
 	}{arg1})
 	fake.recordInvocation("Submit", []interface{}{arg1})
 	fake.submitMutex.Unlock()
@@ -47,13 +48,13 @@ func (fake *Replicator) SubmitCallCount() int {
 	return len(fake.submitArgsForCall)
 }
 
-func (fake *Replicator) SubmitCalls(stub func(interface{}) error) {
+func (fake *Replicator) SubmitCalls(stub func(*types.Block) error) {
 	fake.submitMutex.Lock()
 	defer fake.submitMutex.Unlock()
 	fake.SubmitStub = stub
 }
 
-func (fake *Replicator) SubmitArgsForCall(i int) interface{} {
+func (fake *Replicator) SubmitArgsForCall(i int) *types.Block {
 	fake.submitMutex.RLock()
 	defer fake.submitMutex.RUnlock()
 	argsForCall := fake.submitArgsForCall[i]

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -51,13 +51,13 @@ func (c *ClosedError) Error() string {
 // NotLeaderError is an error that denotes that the current node is not the cluster leader.
 // The error carries the identity of the leader if it is known (>0), or 0 if it is not.
 type NotLeaderError struct {
-	LeaderID int
+	LeaderID uint64
 }
 
 func (n *NotLeaderError) Error() string {
 	return fmt.Sprintf("not a leader, leader is: %d", n.LeaderID)
 }
 
-func (n *NotLeaderError) GetLeaderID() int {
+func (n *NotLeaderError) GetLeaderID() uint64 {
 	return n.LeaderID
 }

--- a/internal/replication/blockreplicator_test.go
+++ b/internal/replication/blockreplicator_test.go
@@ -4,120 +4,244 @@
 package replication_test
 
 import (
-	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+	"github.com/IBM-Blockchain/bcdb-server/internal/comm"
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"math"
+	"os"
+	"path"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/IBM-Blockchain/bcdb-server/config"
 	ierrors "github.com/IBM-Blockchain/bcdb-server/internal/errors"
 	"github.com/IBM-Blockchain/bcdb-server/internal/queue"
 	"github.com/IBM-Blockchain/bcdb-server/internal/replication"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/logger"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
 	"github.com/stretchr/testify/require"
 )
 
-var clusterConfig1node = &types.ClusterConfig{
-	Nodes: []*types.NodeConfig{{
-		Id:      "node1",
-		Address: "127.0.0.1",
-		Port:    9090,
-	}},
-	ConsensusConfig: &types.ConsensusConfig{
-		Algorithm: "raft",
-		Members: []*types.PeerConfig{{
-			NodeId:   "node1",
-			RaftId:   1,
-			PeerHost: "127.0.0.1",
-			PeerPort: 9091,
-		}},
-		RaftConfig: &types.RaftConfig{
-			TickInterval:   "100ms",
-			ElectionTicks:  100,
-			HeartbeatTicks: 10,
-		},
-	},
-}
+func TestBlockReplicator_StartClose_Fast(t *testing.T) {
+	env := testEnv1node(t, "info")
+	require.NotNil(t, env)
+	defer os.RemoveAll(env.testDir)
 
-func TestBlockReplicator_StartClose(t *testing.T) {
-	lg := testLogger(t, "debug")
-	qBarrier := queue.NewOneQueueBarrier(lg)
-	conf := &replication.Config{BlockOneQueueBarrier: qBarrier, Logger: lg}
-	blockReplicator := replication.NewBlockReplicator(conf)
-
-	blockReplicator.Start()
-	err := blockReplicator.Close()
+	err := env.conf.Transport.Start()
 	require.NoError(t, err)
 
-	err = qBarrier.Close()
+	env.blockReplicator.Start()
+	err = env.blockReplicator.Close()
+	require.NoError(t, err)
+
+	env.conf.Transport.Close()
+
+	err = env.conf.BlockOneQueueBarrier.Close()
 	require.EqualError(t, err, "closed")
 
-	err = blockReplicator.Close()
+	err = env.blockReplicator.Close()
 	require.EqualError(t, err, "block replicator already closed")
+}
+
+func TestBlockReplicator_StartClose_Slow(t *testing.T) {
+	env := testEnv1node(t, "info")
+	require.NotNil(t, env)
+	defer os.RemoveAll(env.testDir)
+
+	err := env.conf.Transport.Start()
+	require.NoError(t, err)
+	env.blockReplicator.Start()
+
+	// wait for the node to become leader
+	isLeaderCond := func() bool {
+		return env.blockReplicator.IsLeader() == nil
+	}
+	assert.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
+
+	err = env.blockReplicator.Close()
+	require.NoError(t, err)
+
+	env.conf.Transport.Close()
+
+	err = env.conf.BlockOneQueueBarrier.Close()
+	require.EqualError(t, err, "closed")
+
+	err = env.blockReplicator.Close()
+	require.EqualError(t, err, "block replicator already closed")
+}
+
+func TestBlockReplicator_Restart(t *testing.T) {
+	env := testEnv1node(t, "info")
+	require.NotNil(t, env)
+	defer os.RemoveAll(env.testDir)
+
+	err := env.conf.Transport.Start()
+	require.NoError(t, err)
+	env.blockReplicator.Start()
+
+	// wait for the node to become leader
+	isLeaderCond := func() bool {
+		return env.blockReplicator.IsLeader() == nil
+	}
+	assert.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
+
+	err = env.blockReplicator.Close()
+	require.NoError(t, err)
+	env.conf.Transport.Close()
+
+	//recreate
+	env.conf.Transport = comm.NewHTTPTransport(&comm.Config{LocalConf: env.conf.LocalConf, Logger: env.conf.Logger})
+	env.conf.BlockOneQueueBarrier = queue.NewOneQueueBarrier(env.conf.Logger)
+	env.blockReplicator, err = replication.NewBlockReplicator(env.conf)
+	require.NoError(t, err)
+	err = env.conf.Transport.SetConsensusListener(env.blockReplicator)
+	require.NoError(t, err)
+	err = env.conf.Transport.UpdateClusterConfig(env.conf.ClusterConfig)
+	require.NoError(t, err)
+
+	//restart
+	err = env.conf.Transport.Start()
+	require.NoError(t, err)
+	env.blockReplicator.Start()
+
+	assert.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
+
+	err = env.blockReplicator.Close()
+	require.NoError(t, err)
+	env.conf.Transport.Close()
 }
 
 func TestBlockReplicator_Submit(t *testing.T) {
 	t.Run("normal flow", func(t *testing.T) {
-		lg := testLogger(t, "debug")
-		qBarrier := queue.NewOneQueueBarrier(lg)
-		conf := &replication.Config{BlockOneQueueBarrier: qBarrier, Logger: lg}
-		blockReplicator := replication.NewBlockReplicator(conf)
-		blockReplicator.Start()
+		env := testEnv1node(t, "debug")
+		require.NotNil(t, env)
+		defer os.RemoveAll(env.testDir)
 
-		block := "block number 1"
-		err := blockReplicator.Submit(block)
+		err := env.conf.Transport.Start()
 		require.NoError(t, err)
-		block2commit, err := qBarrier.Dequeue()
+		env.blockReplicator.Start()
+
+		// wait for the node to become leader
+		isLeaderCond := func() bool {
+			return env.blockReplicator.IsLeader() == nil
+		}
+		assert.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
+
+		proposeBlock := &types.Block{
+			Header: &types.BlockHeader{
+				BaseHeader: &types.BlockHeaderBase{
+					Number:                1,
+					LastCommittedBlockNum: 0,
+				},
+			},
+		}
+
+		err = env.blockReplicator.Submit(proposeBlock)
+		require.NoError(t, err)
+
+		block2commit, err := env.conf.BlockOneQueueBarrier.Dequeue()
 		require.NoError(t, err)
 		require.NotNil(t, block2commit)
-		require.Equal(t, block, block2commit.(string))
-		err = qBarrier.Reply(nil)
+		require.True(t, proto.Equal(proposeBlock.GetHeader(), block2commit.(*types.Block).GetHeader()), "in: %+v, out: %+v", proposeBlock, block2commit)
+		require.NotNil(t, block2commit.(*types.Block).GetConsensusMetadata())
+		raftIndex := block2commit.(*types.Block).GetConsensusMetadata().GetRaftIndex()
+		require.True(t, raftIndex > 0)
+		err = env.conf.BlockOneQueueBarrier.Reply(nil)
 		require.NoError(t, err)
 
-		block = "block number 2"
-		err = blockReplicator.Submit(block)
+		proposeBlock = &types.Block{
+			Header: &types.BlockHeader{
+				BaseHeader: &types.BlockHeaderBase{
+					Number:                2,
+					LastCommittedBlockNum: 1,
+				},
+			},
+		}
+		err = env.blockReplicator.Submit(proposeBlock)
 		require.NoError(t, err)
-		block2commit, err = qBarrier.Dequeue()
+		block2commit, err = env.conf.BlockOneQueueBarrier.Dequeue()
 		require.NoError(t, err)
 		require.NotNil(t, block2commit)
-		require.Equal(t, block, block2commit.(string))
-		err = qBarrier.Reply(nil)
+		require.True(t, proto.Equal(proposeBlock.GetHeader(), block2commit.(*types.Block).GetHeader()), "in: %+v, out: %+v", proposeBlock, block2commit)
+		require.NotNil(t, block2commit.(*types.Block).GetConsensusMetadata())
+		require.True(t, block2commit.(*types.Block).GetConsensusMetadata().GetRaftIndex() > raftIndex)
+		err = env.conf.BlockOneQueueBarrier.Reply(nil)
 		require.NoError(t, err)
 
-		err = blockReplicator.Close()
+		err = env.blockReplicator.Close()
 		require.NoError(t, err)
+		env.conf.Transport.Close()
 	})
 
-	t.Run("normal flow: close before reply", func(t *testing.T) {
-		lg := testLogger(t, "debug")
-		qBarrier := queue.NewOneQueueBarrier(lg)
-		conf := &replication.Config{BlockOneQueueBarrier: qBarrier, Logger: lg}
-		blockReplicator := replication.NewBlockReplicator(conf)
-		blockReplicator.Start()
+	t.Run("normal flow: close before commit reply", func(t *testing.T) {
+		env := testEnv1node(t, "debug")
+		require.NotNil(t, env)
+		defer os.RemoveAll(env.testDir)
 
-		block := "block number 1"
-		err := blockReplicator.Submit(block)
+		err := env.conf.Transport.Start()
 		require.NoError(t, err)
-		block2commit, err := qBarrier.Dequeue()
+		env.blockReplicator.Start()
+
+		// wait for the node to become leader
+		isLeaderCond := func() bool {
+			return env.blockReplicator.IsLeader() == nil
+		}
+		assert.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
+
+		block := &types.Block{
+			Header: &types.BlockHeader{
+				BaseHeader: &types.BlockHeaderBase{
+					Number:                1,
+					LastCommittedBlockNum: 0,
+				},
+			},
+		}
+
+		err = env.blockReplicator.Submit(block)
+		require.NoError(t, err)
+
+		block2commit, err := env.conf.BlockOneQueueBarrier.Dequeue()
 		require.NoError(t, err)
 		require.NotNil(t, block2commit)
-		require.Equal(t, block, block2commit.(string))
 
-		err = blockReplicator.Close()
+		err = env.blockReplicator.Close()
 		require.NoError(t, err)
+		env.conf.Transport.Close()
 	})
 
 	t.Run("normal flow: blocked submit", func(t *testing.T) {
-		lg := testLogger(t, "debug")
-		qBarrier := queue.NewOneQueueBarrier(lg)
-		conf := &replication.Config{BlockOneQueueBarrier: qBarrier, Logger: lg}
-		blockReplicator := replication.NewBlockReplicator(conf)
-		blockReplicator.Start()
+		env := testEnv1node(t, "debug")
+		require.NotNil(t, env)
+		defer os.RemoveAll(env.testDir)
+
+		err := env.conf.Transport.Start()
+		require.NoError(t, err)
+		env.blockReplicator.Start()
+
+		// wait for the node to become leader
+		isLeaderCond := func() bool {
+			return env.blockReplicator.IsLeader() == nil
+		}
+		assert.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
 
 		var wg sync.WaitGroup
 		wg.Add(1)
-		block := "some block"
+
 		submitManyTillClosed := func() {
-			for i := 0; i < 1000; i++ { // larger then the raft pipeline channel
-				err := blockReplicator.Submit(block)
+			for i := 0; i < 1000; i++ { // larger then the raft pipeline
+				block := &types.Block{
+					Header: &types.BlockHeader{
+						BaseHeader: &types.BlockHeaderBase{
+							Number:                uint64(i + 1),
+							LastCommittedBlockNum: uint64(i),
+						},
+					},
+				}
+
+				err := env.blockReplicator.Submit(block)
 				if i == 0 {
 					require.NoError(t, err)
 				}
@@ -132,18 +256,225 @@ func TestBlockReplicator_Submit(t *testing.T) {
 
 		go submitManyTillClosed()
 
-		block2commit, err := qBarrier.Dequeue()
+		block2commit, err := env.conf.BlockOneQueueBarrier.Dequeue()
 		require.NoError(t, err)
 		require.NotNil(t, block2commit)
-		require.Equal(t, block, block2commit.(string))
-		err = qBarrier.Reply(nil)
+		require.Equal(t, uint64(1), block2commit.(*types.Block).GetHeader().GetBaseHeader().GetNumber())
+		err = env.conf.BlockOneQueueBarrier.Reply(nil)
 		require.NoError(t, err)
 
-		err = blockReplicator.Close()
+		err = env.blockReplicator.Close()
 		require.NoError(t, err)
+		env.conf.Transport.Close()
 
 		wg.Wait()
 	})
+
+	t.Run("restart", func(t *testing.T) {
+		env := testEnv1node(t, "debug")
+		require.NotNil(t, env)
+		defer os.RemoveAll(env.testDir)
+
+		err := env.conf.Transport.Start()
+		require.NoError(t, err)
+		env.blockReplicator.Start()
+
+		// wait for the node to become leader
+		isLeaderCond := func() bool {
+			return env.blockReplicator.IsLeader() == nil
+		}
+		assert.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
+
+		proposedBlock := &types.Block{
+			Header: &types.BlockHeader{
+				BaseHeader: &types.BlockHeaderBase{
+					Number: 2,
+				},
+			},
+		}
+		err = env.blockReplicator.Submit(proposedBlock)
+		require.NoError(t, err)
+
+		block2commit, err := env.conf.BlockOneQueueBarrier.Dequeue()
+		require.NoError(t, err)
+		err = env.ledger.Append(block2commit.(*types.Block))
+		require.NoError(t, err)
+		err = env.conf.BlockOneQueueBarrier.Reply(nil)
+		require.NoError(t, err)
+
+		proposedBlock = &types.Block{
+			Header: &types.BlockHeader{
+				BaseHeader: &types.BlockHeaderBase{
+					Number: 3,
+				},
+			},
+		}
+		err = env.blockReplicator.Submit(proposedBlock)
+		require.NoError(t, err)
+		block2commit, err = env.conf.BlockOneQueueBarrier.Dequeue()
+		require.NoError(t, err)
+		err = env.ledger.Append(block2commit.(*types.Block))
+		require.NoError(t, err)
+		err = env.conf.BlockOneQueueBarrier.Reply(nil)
+		require.NoError(t, err)
+
+		// close
+		err = env.blockReplicator.Close()
+		require.NoError(t, err)
+		env.conf.Transport.Close()
+
+		//recreate
+		env.conf.Transport = comm.NewHTTPTransport(&comm.Config{LocalConf: env.conf.LocalConf, Logger: env.conf.Logger})
+		env.conf.BlockOneQueueBarrier = queue.NewOneQueueBarrier(env.conf.Logger)
+		env.blockReplicator, err = replication.NewBlockReplicator(env.conf)
+		require.NoError(t, err)
+		err = env.conf.Transport.SetConsensusListener(env.blockReplicator)
+		require.NoError(t, err)
+		err = env.conf.Transport.UpdateClusterConfig(env.conf.ClusterConfig)
+		require.NoError(t, err)
+
+		//restart
+		err = env.conf.Transport.Start()
+		require.NoError(t, err)
+		env.blockReplicator.Start()
+
+		isLeaderCond = func() bool {
+			return env.blockReplicator.IsLeader() == nil
+		}
+		assert.Eventually(t, isLeaderCond, 30*time.Second, 100*time.Millisecond)
+
+		proposedBlock = &types.Block{
+			Header: &types.BlockHeader{
+				BaseHeader: &types.BlockHeaderBase{
+					Number: 4,
+				},
+			},
+		}
+		err = env.blockReplicator.Submit(proposedBlock)
+		require.NoError(t, err)
+
+		block2commit, err = env.conf.BlockOneQueueBarrier.Dequeue()
+		require.NoError(t, err)
+		err = env.ledger.Append(block2commit.(*types.Block))
+		require.NoError(t, err)
+		err = env.conf.BlockOneQueueBarrier.Reply(nil)
+		require.NoError(t, err)
+
+		// close
+		err = env.blockReplicator.Close()
+		require.NoError(t, err)
+		env.conf.Transport.Close()
+	})
+}
+
+var clusterConfig1node = &types.ClusterConfig{
+	Nodes: []*types.NodeConfig{&types.NodeConfig{
+		Id:          "node1",
+		Address:     "127.0.0.1",
+		Port:        22001,
+		Certificate: []byte("bogus-cert"),
+	}},
+	ConsensusConfig: &types.ConsensusConfig{
+		Algorithm: "raft",
+		Members: []*types.PeerConfig{{
+			NodeId:   "node1",
+			RaftId:   1,
+			PeerHost: "127.0.0.1",
+			PeerPort: 23001,
+		}},
+		RaftConfig: &types.RaftConfig{
+			TickInterval:         "20ms",
+			ElectionTicks:        100,
+			HeartbeatTicks:       10,
+			MaxInflightBlocks:    50,
+			SnapshotIntervalSize: math.MaxUint64,
+		},
+	},
+}
+
+type testEnv struct {
+	testDir         string
+	conf            *replication.Config
+	blockReplicator *replication.BlockReplicator
+	ledger          *memLedger
+}
+
+func testEnv1node(t *testing.T, level string) *testEnv {
+	lg := testLogger(t, level)
+
+	testDir, err := ioutil.TempDir("", "replication-test")
+	require.NoError(t, err)
+
+	localConf := &config.LocalConfiguration{
+		Server: config.ServerConf{
+			Identity: config.IdentityConf{
+				ID: "node1",
+			},
+		},
+		Replication: config.ReplicationConf{
+			WALDir:  path.Join(testDir, "wal"),
+			SnapDir: path.Join(testDir, "snap"),
+			Network: config.NetworkConf{
+				Address: "127.0.0.1",
+				Port:    23001,
+			},
+			TLS: config.TLSConf{
+				Enabled: false,
+			},
+		},
+	}
+
+	peerTransport := comm.NewHTTPTransport(&comm.Config{
+		LocalConf: localConf,
+		Logger:    lg,
+	})
+
+	qBarrier := queue.NewOneQueueBarrier(lg)
+
+	ledger := &memLedger{}
+	proposedBlock := &types.Block{
+		Header: &types.BlockHeader{
+			BaseHeader: &types.BlockHeaderBase{
+				Number: 1,
+			},
+		},
+	}
+	err = ledger.Append(proposedBlock) //genesis block
+	require.NoError(t, err)
+
+	conf := &replication.Config{
+		LocalConf:            localConf,
+		ClusterConfig:        clusterConfig1node,
+		LedgerReader:         ledger,
+		Transport:            peerTransport,
+		BlockOneQueueBarrier: qBarrier,
+		Logger:               lg,
+	}
+
+	blockReplicator, err := replication.NewBlockReplicator(conf)
+	if err != nil {
+		os.RemoveAll(testDir)
+		return nil
+	}
+
+	err = conf.Transport.SetConsensusListener(blockReplicator)
+	if err != nil {
+		os.RemoveAll(testDir)
+		return nil
+	}
+
+	err = conf.Transport.UpdateClusterConfig(conf.ClusterConfig)
+	if err != nil {
+		os.RemoveAll(testDir)
+		return nil
+	}
+
+	return &testEnv{
+		testDir:         testDir,
+		conf:            conf,
+		blockReplicator: blockReplicator,
+		ledger:          ledger,
+	}
 }
 
 func testLogger(t *testing.T, level string) *logger.SugarLogger {
@@ -156,4 +487,41 @@ func testLogger(t *testing.T, level string) *logger.SugarLogger {
 	lg, err := logger.New(c)
 	require.NoError(t, err)
 	return lg
+}
+
+type memLedger struct {
+	mutex  sync.Mutex
+	ledger []*types.Block
+}
+
+func (l *memLedger) Height() (uint64, error) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	return uint64(len(l.ledger)), nil
+}
+
+func (l *memLedger) Append(block *types.Block) error {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if h := len(l.ledger); h > 0 {
+		if l.ledger[h-1].GetHeader().GetBaseHeader().GetNumber()+1 != block.GetHeader().GetBaseHeader().Number {
+			return errors.Errorf("block number [%d] out of sequence, expected [%d]",
+				block.GetHeader().GetBaseHeader().Number, l.ledger[h-1].GetHeader().GetBaseHeader().GetNumber()+1)
+		}
+	}
+
+	l.ledger = append(l.ledger, block)
+	return nil
+}
+
+func (l *memLedger) Get(blockNum uint64) (*types.Block, error) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if blockNum-1 >= uint64(len(l.ledger)) {
+		return nil, errors.Errorf("block number out of bounds: %d, len: %d", blockNum, len(l.ledger))
+	}
+	return l.ledger[blockNum-1], nil
 }

--- a/internal/replication/storage.go
+++ b/internal/replication/storage.go
@@ -1,0 +1,432 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package replication
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/IBM-Blockchain/bcdb-server/pkg/logger"
+	"github.com/pkg/errors"
+	"go.etcd.io/etcd/etcdserver/api/snap"
+	"go.etcd.io/etcd/pkg/fileutil"
+	"go.etcd.io/etcd/raft"
+	"go.etcd.io/etcd/raft/raftpb"
+	"go.etcd.io/etcd/wal"
+	"go.etcd.io/etcd/wal/walpb"
+)
+
+// MaxSnapshotFiles defines max number of etcd/raft snapshot files to retain
+// on filesystem. Snapshot files are read from newest to oldest, until first
+// intact file is found. The more snapshot files we keep around, the more we
+// mitigate the impact of a corrupted snapshots. This is exported for testing
+// purpose. This MUST be greater equal than 1.
+var MaxSnapshotFiles = 4
+
+// RaftStorage encapsulates storages needed for etcd/raft data, i.e. memory, wal
+type RaftStorage struct {
+	SnapshotCatchUpEntries uint64
+
+	walDir  string
+	snapDir string
+
+	lg *logger.SugarLogger
+
+	MemoryStorage *raft.MemoryStorage
+	wal           *wal.WAL
+	snap          *snap.Snapshotter
+
+	// a queue that keeps track of indices of snapshots on disk
+	snapshotIndex []uint64
+}
+
+// CreateStorage attempts to create a storage to persist etcd/raft data.
+// If data presents in specified disk, they are loaded to reconstruct storage state.
+func CreateStorage(lg *logger.SugarLogger, walDir string, snapDir string) (*RaftStorage, error) {
+
+	sn, err := createSnapshotter(lg, snapDir)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshot, err := sn.Load()
+	if err != nil {
+		if err == snap.ErrNoSnapshot {
+			lg.Debugf("No snapshot found at %s", snapDir)
+		} else {
+			return nil, errors.Errorf("failed to load snapshot: %s", err)
+		}
+	} else {
+		// snapshot found
+		lg.Debugf("Loaded snapshot at Term %d and Index %d, ConfState: %+v",
+			snapshot.Metadata.Term, snapshot.Metadata.Index, snapshot.Metadata.ConfState)
+	}
+
+	w, st, ents, err := createOrReadWAL(lg, walDir, snapshot)
+	if err != nil {
+		return nil, errors.Errorf("failed to create or read WAL: %s", err)
+	}
+
+	ms := raft.NewMemoryStorage()
+	if snapshot != nil {
+		lg.Debugf("Applying snapshot to raft MemoryStorage")
+		if err := ms.ApplySnapshot(*snapshot); err != nil {
+			return nil, errors.Errorf("Failed to apply snapshot to memory: %s", err)
+		}
+	}
+
+	lg.Debugf("Setting HardState to {Term: %d, Commit: %d}", st.Term, st.Commit)
+	ms.SetHardState(st) // MemoryStorage.SetHardState always returns nil
+
+	lg.Debugf("Appending %d entries to memory storage", len(ents))
+	ms.Append(ents) // MemoryStorage.Append always return nil
+
+	return &RaftStorage{
+		lg:            lg,
+		MemoryStorage: ms,
+		wal:           w,
+		snap:          sn,
+		walDir:        walDir,
+		snapDir:       snapDir,
+		snapshotIndex: ListSnapshots(lg, snapDir),
+	}, nil
+}
+
+// ListSnapshots returns a list of RaftIndex of snapshots stored on disk.
+// If a file is corrupted, rename the file.
+func ListSnapshots(logger *logger.SugarLogger, snapDir string) []uint64 {
+	dir, err := os.Open(snapDir)
+	if err != nil {
+		logger.Errorf("Failed to open snapshot directory %s: %s", snapDir, err)
+		return nil
+	}
+	defer dir.Close()
+
+	filenames, err := dir.Readdirnames(-1)
+	if err != nil {
+		logger.Errorf("Failed to read snapshot files: %s", err)
+		return nil
+	}
+
+	snapfiles := []string{}
+	for i := range filenames {
+		if strings.HasSuffix(filenames[i], ".snap") {
+			snapfiles = append(snapfiles, filenames[i])
+		}
+	}
+	sort.Strings(snapfiles)
+
+	var snapshots []uint64
+	for _, snapfile := range snapfiles {
+		fpath := filepath.Join(snapDir, snapfile)
+		s, err := snap.Read(logger.Desugar(), fpath)
+		if err != nil {
+			logger.Errorf("Snapshot file %s is corrupted: %s", fpath, err)
+
+			broken := fpath + ".broken"
+			if err = os.Rename(fpath, broken); err != nil {
+				logger.Errorf("Failed to rename corrupted snapshot file %s to %s: %s", fpath, broken, err)
+			} else {
+				logger.Debugf("Renaming corrupted snapshot file %s to %s", fpath, broken)
+			}
+
+			continue
+		}
+
+		snapshots = append(snapshots, s.Metadata.Index)
+	}
+
+	return snapshots
+}
+
+func createSnapshotter(logger *logger.SugarLogger, snapDir string) (*snap.Snapshotter, error) {
+	if err := os.MkdirAll(snapDir, os.ModePerm); err != nil {
+		return nil, errors.Errorf("failed to mkdir '%s' for snapshot: %s", snapDir, err)
+	}
+
+	return snap.New(logger.Desugar(), snapDir), nil
+}
+
+func createOrReadWAL(lg *logger.SugarLogger, walDir string, snapshot *raftpb.Snapshot) (w *wal.WAL, st raftpb.HardState, ents []raftpb.Entry, err error) {
+	if !wal.Exist(walDir) {
+		lg.Infof("No WAL data found, creating new WAL at path '%s'", walDir)
+		// TODO(jay_guo) add metadata to be persisted with wal once we need it.
+		// use case could be data dump and restore on a new node.
+		w, err := wal.Create(lg.Desugar(), walDir, nil)
+		if err == os.ErrExist {
+			lg.Fatalf("programming error, we've just checked that WAL does not exist")
+		}
+
+		if err != nil {
+			return nil, st, nil, errors.Errorf("failed to initialize WAL: %s", err)
+		}
+
+		if err = w.Close(); err != nil {
+			return nil, st, nil, errors.Errorf("failed to close the WAL just created: %s", err)
+		}
+	} else {
+		lg.Infof("Found WAL data at path '%s', replaying it", walDir)
+	}
+
+	walsnap := walpb.Snapshot{}
+	if snapshot != nil {
+		walsnap.Index, walsnap.Term = snapshot.Metadata.Index, snapshot.Metadata.Term
+	}
+
+	lg.Debugf("Loading WAL at Term %d and Index %d", walsnap.Term, walsnap.Index)
+
+	var repaired bool
+	for {
+		if w, err = wal.Open(lg.Desugar(), walDir, walsnap); err != nil {
+			return nil, st, nil, errors.Errorf("failed to open WAL: %s", err)
+		}
+
+		if _, st, ents, err = w.ReadAll(); err != nil {
+			lg.Warnf("Failed to read WAL: %s", err)
+
+			if errc := w.Close(); errc != nil {
+				return nil, st, nil, errors.Errorf("failed to close erroneous WAL: %s", errc)
+			}
+
+			// only repair UnexpectedEOF and only repair once
+			if repaired || err != io.ErrUnexpectedEOF {
+				return nil, st, nil, errors.Errorf("failed to read WAL and cannot repair: %s", err)
+			}
+
+			if !wal.Repair(lg.Desugar(), walDir) {
+				return nil, st, nil, errors.Errorf("failed to repair WAL: %s", err)
+			}
+
+			repaired = true
+			// next loop should be able to open WAL and return
+			continue
+		}
+
+		// successfully opened WAL and read all entries, break
+		break
+	}
+
+	return w, st, ents, nil
+}
+
+// Snapshot returns the latest snapshot stored in memory
+func (rs *RaftStorage) Snapshot() raftpb.Snapshot {
+	sn, _ := rs.MemoryStorage.Snapshot() // Snapshot always returns nil error
+	return sn
+}
+
+// Store persists etcd/raft data
+func (rs *RaftStorage) Store(entries []raftpb.Entry, hardstate raftpb.HardState, snapshot raftpb.Snapshot) error {
+	if err := rs.wal.Save(hardstate, entries); err != nil {
+		return err
+	}
+
+	if !raft.IsEmptySnap(snapshot) {
+		if err := rs.saveSnap(snapshot); err != nil {
+			return err
+		}
+
+		if err := rs.MemoryStorage.ApplySnapshot(snapshot); err != nil {
+			if err == raft.ErrSnapOutOfDate {
+				rs.lg.Warnf("Attempted to apply out-of-date snapshot at Term %d and Index %d",
+					snapshot.Metadata.Term, snapshot.Metadata.Index)
+			} else {
+				rs.lg.Fatalf("Unexpected programming error: %s", err)
+			}
+		}
+	}
+
+	if err := rs.MemoryStorage.Append(entries); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (rs *RaftStorage) saveSnap(snap raftpb.Snapshot) error {
+	rs.lg.Infof("Persisting snapshot (term: %d, index: %d) to WAL and disk", snap.Metadata.Term, snap.Metadata.Index)
+
+	// must save the snapshot index to the WAL before saving the
+	// snapshot to maintain the invariant that we only Open the
+	// wal at previously-saved snapshot indexes.
+	walsnap := walpb.Snapshot{
+		Index: snap.Metadata.Index,
+		Term:  snap.Metadata.Term,
+	}
+
+	if err := rs.wal.SaveSnapshot(walsnap); err != nil {
+		return errors.Errorf("failed to save snapshot to WAL: %s", err)
+	}
+
+	if err := rs.snap.SaveSnap(snap); err != nil {
+		return errors.Errorf("failed to save snapshot to disk: %s", err)
+	}
+
+	rs.lg.Debugf("Releasing lock to wal files prior to %d", snap.Metadata.Index)
+	if err := rs.wal.ReleaseLockTo(snap.Metadata.Index); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// TakeSnapshot takes a snapshot at index i from MemoryStorage, and persists it to wal and disk.
+func (rs *RaftStorage) TakeSnapshot(i uint64, cs raftpb.ConfState, data []byte) error {
+	rs.lg.Debugf("Creating snapshot at index %d from MemoryStorage", i)
+	snap, err := rs.MemoryStorage.CreateSnapshot(i, &cs, data)
+	if err != nil {
+		return errors.Errorf("failed to create snapshot from MemoryStorage: %s", err)
+	}
+
+	if err = rs.saveSnap(snap); err != nil {
+		return err
+	}
+
+	rs.snapshotIndex = append(rs.snapshotIndex, snap.Metadata.Index)
+
+	// Keep some entries in memory for slow followers to catchup
+	if i > rs.SnapshotCatchUpEntries {
+		compacti := i - rs.SnapshotCatchUpEntries
+		rs.lg.Debugf("Purging in-memory raft entries prior to %d", compacti)
+		if err = rs.MemoryStorage.Compact(compacti); err != nil {
+			if err == raft.ErrCompacted {
+				rs.lg.Warnf("Raft entries prior to %d are already purged", compacti)
+			} else {
+				rs.lg.Fatalf("Failed to purge raft entries: %s", err)
+			}
+		}
+	}
+
+	rs.lg.Infof("Snapshot is taken at index %d", i)
+
+	rs.gc()
+	return nil
+}
+
+// gc collects etcd/raft garbage files, namely wal and snapshot files
+func (rs *RaftStorage) gc() {
+	if len(rs.snapshotIndex) < MaxSnapshotFiles {
+		rs.lg.Debugf("Snapshots on disk (%d) < limit (%d), no need to purge wal/snapshot",
+			len(rs.snapshotIndex), MaxSnapshotFiles)
+		return
+	}
+
+	rs.snapshotIndex = rs.snapshotIndex[len(rs.snapshotIndex)-MaxSnapshotFiles:]
+
+	rs.purgeWAL()
+	rs.purgeSnap()
+}
+
+func (rs *RaftStorage) purgeWAL() {
+	retain := rs.snapshotIndex[0]
+
+	var files []string
+	err := filepath.Walk(rs.walDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !strings.HasSuffix(path, ".wal") {
+			return nil
+		}
+
+		var seq, index uint64
+		_, f := filepath.Split(path)
+		fmt.Sscanf(f, "%016x-%016x.wal", &seq, &index)
+
+		// Only purge WAL with index lower than oldest snapshot.
+		// filepath.SkipDir seizes Walk without returning error.
+		if index >= retain {
+			return filepath.SkipDir
+		}
+
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		rs.lg.Errorf("Failed to read WAL directory %s: %s", rs.walDir, err)
+	}
+
+	if len(files) <= 1 {
+		// we need to keep one wal segment with index smaller than snapshot.
+		// see comment on wal.ReleaseLockTo for the more details.
+		return
+	}
+
+	rs.purge(files[:len(files)-1])
+}
+
+func (rs *RaftStorage) purgeSnap() {
+	var files []string
+	err := filepath.Walk(rs.snapDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if strings.HasSuffix(path, ".snap") {
+			files = append(files, path)
+		} else if strings.HasSuffix(path, ".broken") {
+			rs.lg.Warnf("Found broken snapshot file %s, it can be removed manually", path)
+		}
+
+		return nil
+	})
+	if err != nil {
+		rs.lg.Errorf("Failed to read Snapshot directory %s: %s", rs.snapDir, err)
+		return
+	}
+
+	l := len(files)
+	if l <= MaxSnapshotFiles {
+		return
+	}
+
+	rs.purge(files[:l-MaxSnapshotFiles]) // retain last MaxSnapshotFiles snapshot files
+}
+
+func (rs *RaftStorage) purge(files []string) {
+	for _, file := range files {
+		l, err := fileutil.TryLockFile(file, os.O_WRONLY, fileutil.PrivateFileMode)
+		if err != nil {
+			rs.lg.Debugf("Failed to lock %s, abort purging", file)
+			break
+		}
+
+		if err = os.Remove(file); err != nil {
+			rs.lg.Errorf("Failed to remove %s: %s", file, err)
+		} else {
+			rs.lg.Debugf("Purged file %s", file)
+		}
+
+		if err = l.Close(); err != nil {
+			rs.lg.Errorf("Failed to close file lock %s: %s", l.Name(), err)
+		}
+	}
+}
+
+// ApplySnapshot applies snapshot to local memory storage
+func (rs *RaftStorage) ApplySnapshot(snap raftpb.Snapshot) {
+	if err := rs.MemoryStorage.ApplySnapshot(snap); err != nil {
+		if err == raft.ErrSnapOutOfDate {
+			rs.lg.Warnf("Attempted to apply out-of-date snapshot at Term %d and Index %d",
+				snap.Metadata.Term, snap.Metadata.Index)
+		} else {
+			rs.lg.Fatalf("Unexpected programming error: %s", err)
+		}
+	}
+}
+
+// Close closes storage
+func (rs *RaftStorage) Close() error {
+	if err := rs.wal.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/replication/storage_test.go
+++ b/internal/replication/storage_test.go
@@ -1,0 +1,400 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package replication
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/IBM-Blockchain/bcdb-server/pkg/logger"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/pkg/fileutil"
+	"go.etcd.io/etcd/raft"
+	"go.etcd.io/etcd/raft/raftpb"
+	"go.etcd.io/etcd/wal"
+)
+
+var (
+	err error
+	lg  *logger.SugarLogger
+
+	dataDir, walDir, snapDir string
+
+	ram   *raft.MemoryStorage
+	store *RaftStorage
+)
+
+func setup(t *testing.T) {
+	c := &logger.Config{
+		Level:         "debug",
+		OutputPath:    []string{"stdout"},
+		ErrOutputPath: []string{"stderr"},
+		Encoding:      "console",
+	}
+	lg, err = logger.New(c)
+	require.NoError(t, err)
+
+	ram = raft.NewMemoryStorage()
+	dataDir, err = ioutil.TempDir("", "etcdraft-")
+	require.NoError(t, err)
+	walDir, snapDir = path.Join(dataDir, "wal"), path.Join(dataDir, "snapshot")
+	store, err = CreateStorage(lg, walDir, snapDir)
+	require.NoError(t, err)
+}
+
+func clean(t *testing.T) {
+	err = store.Close()
+	require.NoError(t, err)
+	err = os.RemoveAll(dataDir)
+	require.NoError(t, err)
+}
+
+func fileCount(files []string, suffix string) (c int) {
+	for _, f := range files {
+		if strings.HasSuffix(f, suffix) {
+			c++
+		}
+	}
+	return
+}
+
+func assertFileCount(t *testing.T, wal, snap int) {
+	files, err := fileutil.ReadDir(walDir)
+	require.NoError(t, err)
+	require.Equal(t, wal, fileCount(files, ".wal"), "WAL file count mismatch")
+
+	files, err = fileutil.ReadDir(snapDir)
+	require.NoError(t, err)
+	require.Equal(t, snap, fileCount(files, ".snap"), "Snap file count mismatch")
+}
+
+func TestOpenWAL(t *testing.T) {
+	t.Run("Last WAL file is broken", func(t *testing.T) {
+		setup(t)
+		defer clean(t)
+
+		// create 10 new wal files
+		for i := 0; i < 10; i++ {
+			store.Store(
+				[]raftpb.Entry{{Index: uint64(i), Data: make([]byte, 10)}},
+				raftpb.HardState{},
+				raftpb.Snapshot{},
+			)
+		}
+		assertFileCount(t, 1, 0)
+		lasti, _ := store.MemoryStorage.LastIndex() // it never returns err
+
+		// close current storage
+		err = store.Close()
+		require.NoError(t, err)
+
+		// truncate wal file
+		w := func() string {
+			files, err := fileutil.ReadDir(walDir)
+			require.NoError(t, err)
+			for _, f := range files {
+				if strings.HasSuffix(f, ".wal") {
+					return path.Join(walDir, f)
+				}
+			}
+			t.FailNow()
+			return ""
+		}()
+		err = os.Truncate(w, 200)
+		require.NoError(t, err)
+
+		// create new storage
+		ram = raft.NewMemoryStorage()
+		store, err = CreateStorage(lg, walDir, snapDir)
+		require.NoError(t, err)
+		lastI, _ := store.MemoryStorage.LastIndex()
+		require.True(t, lastI > 0)     // we are still able to read some entries
+		require.True(t, lasti > lastI) // but less than before because some are broken
+	})
+}
+
+func TestTakeSnapshot(t *testing.T) {
+	// To make this test more understandable, here's a list
+	// of expected wal files:
+	// (wal file name format: seq-index.wal, index is the first index in this file)
+	//
+	// 0000000000000000-0000000000000000.wal (this is created initially by etcd/wal)
+	// 0000000000000001-0000000000000001.wal
+	// 0000000000000002-0000000000000002.wal
+	// 0000000000000003-0000000000000003.wal
+	// 0000000000000004-0000000000000004.wal
+	// 0000000000000005-0000000000000005.wal
+	// 0000000000000006-0000000000000006.wal
+	// 0000000000000007-0000000000000007.wal
+	// 0000000000000008-0000000000000008.wal
+	// 0000000000000009-0000000000000009.wal
+	// 000000000000000a-000000000000000a.wal
+
+	t.Run("Good", func(t *testing.T) {
+		t.Run("MaxSnapshotFiles==1", func(t *testing.T) {
+			backup := MaxSnapshotFiles
+			MaxSnapshotFiles = 1
+			defer func() { MaxSnapshotFiles = backup }()
+
+			setup(t)
+			defer clean(t)
+
+			// set SegmentSizeBytes to a small value so that
+			// every entry persisted to wal would result in
+			// a new wal being created.
+			oldSegmentSizeBytes := wal.SegmentSizeBytes
+			wal.SegmentSizeBytes = 10
+			defer func() {
+				wal.SegmentSizeBytes = oldSegmentSizeBytes
+			}()
+
+			// create 10 new wal files
+			for i := 0; i < 10; i++ {
+				store.Store(
+					[]raftpb.Entry{{Index: uint64(i), Data: make([]byte, 100)}},
+					raftpb.HardState{},
+					raftpb.Snapshot{},
+				)
+			}
+
+			assertFileCount(t, 11, 0)
+
+			err = store.TakeSnapshot(uint64(3), raftpb.ConfState{Voters: []uint64{1}}, make([]byte, 10))
+			require.NoError(t, err)
+			// Snapshot is taken at index 3, which releases lock up to 2 (excl.).
+			// This results in wal files with index [0, 1] being purged (2 files)
+			assertFileCount(t, 9, 1)
+
+			err = store.TakeSnapshot(uint64(5), raftpb.ConfState{Voters: []uint64{1}}, make([]byte, 10))
+			require.NoError(t, err)
+			// Snapshot is taken at index 5, which releases lock up to 4 (excl.).
+			// This results in wal files with index [2, 3] being purged (2 files)
+			assertFileCount(t, 7, 1)
+
+			t.Logf("Close the storage and create a new one based on existing files")
+
+			err = store.Close()
+			require.NoError(t, err)
+			store, err = CreateStorage(lg, walDir, snapDir)
+			require.NoError(t, err)
+
+			err = store.TakeSnapshot(uint64(7), raftpb.ConfState{Voters: []uint64{1}}, make([]byte, 10))
+			require.NoError(t, err)
+			// Snapshot is taken at index 7, which releases lock up to 6 (excl.).
+			// This results in wal files with index [4, 5] being purged (2 file)
+			assertFileCount(t, 5, 1)
+
+			err = store.TakeSnapshot(uint64(9), raftpb.ConfState{Voters: []uint64{1}}, make([]byte, 10))
+			require.NoError(t, err)
+			// Snapshot is taken at index 9, which releases lock up to 8 (excl.).
+			// This results in wal files with index [6, 7] being purged (2 file)
+			assertFileCount(t, 3, 1)
+		})
+
+		t.Run("MaxSnapshotFiles==2", func(t *testing.T) {
+			backup := MaxSnapshotFiles
+			MaxSnapshotFiles = 2
+			defer func() { MaxSnapshotFiles = backup }()
+
+			setup(t)
+			defer clean(t)
+
+			// set SegmentSizeBytes to a small value so that
+			// every entry persisted to wal would result in
+			// a new wal being created.
+			oldSegmentSizeBytes := wal.SegmentSizeBytes
+			wal.SegmentSizeBytes = 10
+			defer func() {
+				wal.SegmentSizeBytes = oldSegmentSizeBytes
+			}()
+
+			// create 10 new wal files
+			for i := 0; i < 10; i++ {
+				store.Store(
+					[]raftpb.Entry{{Index: uint64(i), Data: make([]byte, 100)}},
+					raftpb.HardState{},
+					raftpb.Snapshot{},
+				)
+			}
+
+			assertFileCount(t, 11, 0)
+
+			// Only one snapshot is taken, no wal pruning happened
+			err = store.TakeSnapshot(uint64(3), raftpb.ConfState{Voters: []uint64{1}}, make([]byte, 10))
+			require.NoError(t, err)
+			assertFileCount(t, 11, 1)
+
+			// Two snapshots at index 3, 5. And we keep one extra wal file prior to oldest snapshot.
+			// So we should have pruned wal file with index [0, 1]
+			err = store.TakeSnapshot(uint64(5), raftpb.ConfState{Voters: []uint64{1}}, make([]byte, 10))
+			require.NoError(t, err)
+			assertFileCount(t, 9, 2)
+
+			t.Logf("Close the storage and create a new one based on existing files")
+
+			err = store.Close()
+			require.NoError(t, err)
+			store, err = CreateStorage(lg, walDir, snapDir)
+			require.NoError(t, err)
+
+			// Two snapshots at index 5, 7. And we keep one extra wal file prior to oldest snapshot.
+			// So we should have pruned wal file with index [2, 3]
+			err = store.TakeSnapshot(uint64(7), raftpb.ConfState{Voters: []uint64{1}}, make([]byte, 10))
+			require.NoError(t, err)
+			assertFileCount(t, 7, 2)
+
+			// Two snapshots at index 7, 9. And we keep one extra wal file prior to oldest snapshot.
+			// So we should have pruned wal file with index [4, 5]
+			err = store.TakeSnapshot(uint64(9), raftpb.ConfState{Voters: []uint64{1}}, make([]byte, 10))
+			require.NoError(t, err)
+			assertFileCount(t, 5, 2)
+		})
+	})
+
+	t.Run("Bad", func(t *testing.T) {
+
+		t.Run("MaxSnapshotFiles==2", func(t *testing.T) {
+			// If latest snapshot file is corrupted, storage should be able
+			// to recover from an older one.
+
+			backup := MaxSnapshotFiles
+			MaxSnapshotFiles = 2
+			defer func() { MaxSnapshotFiles = backup }()
+
+			setup(t)
+			defer clean(t)
+
+			// set SegmentSizeBytes to a small value so that
+			// every entry persisted to wal would result in
+			// a new wal being created.
+			oldSegmentSizeBytes := wal.SegmentSizeBytes
+			wal.SegmentSizeBytes = 10
+			defer func() {
+				wal.SegmentSizeBytes = oldSegmentSizeBytes
+			}()
+
+			// create 10 new wal files
+			for i := 0; i < 10; i++ {
+				store.Store(
+					[]raftpb.Entry{{Index: uint64(i), Data: make([]byte, 100)}},
+					raftpb.HardState{},
+					raftpb.Snapshot{},
+				)
+			}
+
+			assertFileCount(t, 11, 0)
+
+			// Only one snapshot is taken, no wal pruning happened
+			err = store.TakeSnapshot(uint64(3), raftpb.ConfState{Voters: []uint64{1}}, make([]byte, 10))
+			require.NoError(t, err)
+			assertFileCount(t, 11, 1)
+
+			// Two snapshots at index 3, 5. And we keep one extra wal file prior to oldest snapshot.
+			// So we should have pruned wal file with index [0, 1]
+			err = store.TakeSnapshot(uint64(5), raftpb.ConfState{Voters: []uint64{1}}, make([]byte, 10))
+			require.NoError(t, err)
+			assertFileCount(t, 9, 2)
+
+			d, err := os.Open(snapDir)
+			require.NoError(t, err)
+			defer d.Close()
+			names, err := d.Readdirnames(-1)
+			require.NoError(t, err)
+			sort.Sort(sort.Reverse(sort.StringSlice(names)))
+
+			corrupted := filepath.Join(snapDir, names[0])
+			t.Logf("Corrupt latest snapshot file: %s", corrupted)
+			f, err := os.OpenFile(corrupted, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+			require.NoError(t, err)
+			_, err = f.WriteString("Corrupted Snapshot")
+			require.NoError(t, err)
+			f.Close()
+
+			// Corrupted snapshot file should've been renamed by ListSnapshots
+			_ = ListSnapshots(lg, snapDir)
+			assertFileCount(t, 9, 1)
+
+			// Rollback the rename
+			broken := corrupted + ".broken"
+			err = os.Rename(broken, corrupted)
+			require.NoError(t, err)
+			assertFileCount(t, 9, 2)
+
+			t.Logf("Close the storage and create a new one based on existing files")
+
+			err = store.Close()
+			require.NoError(t, err)
+			store, err = CreateStorage(lg, walDir, snapDir)
+			require.NoError(t, err)
+
+			// Corrupted snapshot file should've been renamed by CreateStorage
+			assertFileCount(t, 9, 1)
+
+			files, err := fileutil.ReadDir(snapDir)
+			require.NoError(t, err)
+			require.Equal(t, 1, fileCount(files, ".broken"))
+
+			err = store.TakeSnapshot(uint64(7), raftpb.ConfState{Voters: []uint64{1}}, make([]byte, 10))
+			require.NoError(t, err)
+			assertFileCount(t, 9, 2)
+
+			err = store.TakeSnapshot(uint64(9), raftpb.ConfState{Voters: []uint64{1}}, make([]byte, 10))
+			require.NoError(t, err)
+			assertFileCount(t, 5, 2)
+		})
+	})
+}
+
+func TestApplyOutOfDateSnapshot(t *testing.T) {
+	t.Run("Apply out of date snapshot", func(t *testing.T) {
+		setup(t)
+		defer clean(t)
+
+		// set SegmentSizeBytes to a small value so that
+		// every entry persisted to wal would result in
+		// a new wal being created.
+		oldSegmentSizeBytes := wal.SegmentSizeBytes
+		wal.SegmentSizeBytes = 10
+		defer func() {
+			wal.SegmentSizeBytes = oldSegmentSizeBytes
+		}()
+
+		// create 10 new wal files
+		for i := 0; i < 10; i++ {
+			store.Store(
+				[]raftpb.Entry{{Index: uint64(i), Data: make([]byte, 100)}},
+				raftpb.HardState{},
+				raftpb.Snapshot{},
+			)
+		}
+		assertFileCount(t, 11, 0)
+
+		err = store.TakeSnapshot(uint64(3), raftpb.ConfState{Voters: []uint64{1}}, make([]byte, 10))
+		require.NoError(t, err)
+		assertFileCount(t, 11, 1)
+
+		snapshot := store.Snapshot()
+		require.NotNil(t, snapshot)
+
+		// Applying old snapshot should have no effect
+		store.ApplySnapshot(snapshot)
+
+		// Storing old snapshot gets no error
+		err := store.Store(
+			[]raftpb.Entry{{Index: uint64(10), Data: make([]byte, 100)}},
+			raftpb.HardState{},
+			snapshot,
+		)
+		require.NoError(t, err)
+		assertFileCount(t, 12, 1)
+	})
+}

--- a/internal/replication/utils.go
+++ b/internal/replication/utils.go
@@ -1,0 +1,27 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package replication
+
+import (
+	"fmt"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+	"go.etcd.io/etcd/raft"
+	"go.etcd.io/etcd/raft/raftpb"
+	"hash/crc64"
+)
+
+func raftPeers(config *types.ClusterConfig) []raft.Peer {
+	var peers []raft.Peer
+	for _, m := range config.ConsensusConfig.Members {
+		peers = append(peers, raft.Peer{ID: m.GetRaftId()})
+	}
+	return peers
+}
+
+func raftEntryString(e raftpb.Entry) string {
+	h := crc64.New(crc64.MakeTable(crc64.ISO))
+	h.Write(e.Data)
+	return fmt.Sprintf("{Term:%d Index:%d Type:%v Data(len):%d Data(hash):%X}",
+		e.Term, e.Index, e.Type, len(e.Data), h.Sum64())
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -107,3 +107,11 @@ func getZapLogLevel(level string) (zapcore.Level, error) {
 
 	return logLevel, nil
 }
+
+func (l *SugarLogger) Warning(v ...interface{}) {
+	l.Warn(v...)
+}
+
+func (l *SugarLogger) Warningf(format string, v ...interface{}) {
+	l.Warnf(format, v...)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"fmt"
+	ierrors "github.com/IBM-Blockchain/bcdb-server/internal/errors"
 	"net"
 	"net/http"
 
@@ -124,4 +125,8 @@ func (s *BCDBHTTPServer) Stop() error {
 func (s *BCDBHTTPServer) Port() (port string, err error) {
 	_, port, err = net.SplitHostPort(s.listen.Addr().String())
 	return
+}
+
+func (s *BCDBHTTPServer) IsLeader() *ierrors.NotLeaderError {
+	return s.db.IsLeader()
 }


### PR DESCRIPTION
Import the etcd/raft lib module
Write the main loop that operates the RSM;
- Order(block)
- Deliver(block)

Assumptions:
- No dynamic config changes to membership
- Use (as module) the WAL from etcd 
- Use (copy) `Storage` from Fabric 
- No snapshots: don't create snapshots, don't accept snapshot
- Support node creation
- Support node shutdown and restart
- Test single node only