### PR TITLE
signer utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ goimports:
 .PHONY: binary
 binary:
 	go build -o $(BIN)/bdb cmd/bdb/main.go
+	go build -o $(BIN)/signer cmd/signer/signer.go
 
 .PHONY: test
 test-script: 

--- a/cmd/signer/signer.go
+++ b/cmd/signer/signer.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/IBM-Blockchain/bcdb-server/pkg/crypto"
+)
+
+var help = "all the following two flags must be set. An example command is shown below: \n\n" +
+	"  signer -data='{\"userID\":\"admin\"}\" -privatekey=admin.key\n"
+
+func main() {
+	pKey := flag.String("privatekey", "", "path to the private key to be used for adding a digital signature")
+	data := flag.String("data", "", "json data to be signed. Surround that data with single quotes. An example json data is '{\"userID\":\"admin\"}'")
+
+	flag.CommandLine.Output()
+	flag.Parse()
+
+	if *pKey == "" || *data == "" {
+		fmt.Println(help)
+		flag.PrintDefaults()
+		return
+	}
+
+	signer, err := crypto.NewSigner(
+		&crypto.SignerOptions{
+			KeyFilePath: *pKey,
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	sign, err := signer.Sign([]byte(*data))
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Print(base64.StdEncoding.EncodeToString(sign))
+}

--- a/cmd/signer/signer_test.go
+++ b/cmd/signer/signer_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/pem"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/IBM-Blockchain/bcdb-server/pkg/crypto"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/server/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSigner(t *testing.T) {
+	t.Run("incorrect args", func(t *testing.T) {
+		for _, arg := range []string{
+			"",
+			"-data='{\"userID\":\"admin\"}'",
+			"-privatekey=../../deployment/sample/crypto/admin/admin.key",
+		} {
+			out, err := exec.Command("go", "run", "signer.go", arg).CombinedOutput()
+			require.NoError(t, err)
+
+			expectedOut := help + "\n  -data string\n    \tjson data to be signed. Surround that data with single quotes." +
+				" An example json data is '{\"userID\":\"admin\"}'\n  -privatekey string\n    \tpath to the private key" +
+				" to be used for adding a digital signature\n"
+			require.Equal(t, expectedOut, string(out))
+		}
+	})
+
+	t.Run("correct args", func(t *testing.T) {
+		tempDir, err := ioutil.TempDir("/tmp", "crypto")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Errorf("error while removing test directory: %v", err)
+			}
+		})
+
+		adminCert, adminKey := createAdminCreds(t, tempDir)
+		data := "'{\"user_id\":\"admin\"}'"
+		args := []string{
+			"run",
+			"signer.go",
+			"-data=" + data,
+			"-privatekey=" + adminKey,
+		}
+
+		out, err := exec.Command("go", args...).Output()
+		require.NoError(t, err)
+
+		b, err := ioutil.ReadFile(adminCert)
+		require.NoError(t, err)
+		bl, _ := pem.Decode(b)
+		require.NotNil(t, bl)
+		verifier, err := crypto.NewVerifier(bl.Bytes)
+		require.NoError(t, err)
+
+		signature, err := base64.StdEncoding.DecodeString(string(out))
+		require.NoError(t, err)
+		require.NoError(t, verifier.Verify([]byte(data), signature))
+	})
+}
+
+func createAdminCreds(t *testing.T, tempDir string) (string, string) {
+	rootCAPemCert, caPrivKey, err := testutils.GenerateRootCA("BCDB RootCA", "127.0.0.1")
+	require.NoError(t, err)
+	require.NotNil(t, rootCAPemCert)
+	require.NotNil(t, caPrivKey)
+
+	keyPair, err := tls.X509KeyPair(rootCAPemCert, caPrivKey)
+	require.NoError(t, err)
+	require.NotNil(t, keyPair)
+
+	pemAdminCert, pemAdminKey, err := testutils.IssueCertificate("BCDB Admin", "127.0.0.1", keyPair)
+	require.NoError(t, err)
+	pemAdminCertFile, err := os.Create(path.Join(tempDir, "admin.pem"))
+	require.NoError(t, err)
+	_, err = pemAdminCertFile.Write(pemAdminCert)
+	require.NoError(t, err)
+	require.NoError(t, pemAdminCertFile.Close())
+
+	pemAdminKeyFile, err := os.Create(path.Join(tempDir, "admin.key"))
+	require.NoError(t, err)
+	_, err = pemAdminKeyFile.Write(pemAdminKey)
+	require.NoError(t, err)
+	require.NoError(t, pemAdminKeyFile.Close())
+
+	return filepath.Join(tempDir, "admin.pem"), filepath.Join(tempDir, "admin.key")
+}

--- a/pkg/cryptoservice/signer.go
+++ b/pkg/cryptoservice/signer.go
@@ -34,7 +34,7 @@ func SignQuery(querySigner crypto.Signer, query interface{}) ([]byte, error) {
 		return nil, errors.Errorf("unknown query type: %T", v)
 	}
 
-	return signPayload(querySigner, query)
+	return SignPayload(querySigner, query)
 }
 
 func SignTx(txSigner crypto.Signer, tx interface{}) ([]byte, error) {
@@ -48,10 +48,10 @@ func SignTx(txSigner crypto.Signer, tx interface{}) ([]byte, error) {
 		return nil, errors.Errorf("unknown transaction type: %T", v)
 	}
 
-	return signPayload(txSigner, tx)
+	return SignPayload(txSigner, tx)
 }
 
-func signPayload(signer crypto.Signer, payload interface{}) ([]byte, error) {
+func SignPayload(signer crypto.Signer, payload interface{}) ([]byte, error) {
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit adds an utility that can help the user to add
their digital signature on any data item. This would be used
when user submits query or transaction through `curl` command

Signed-off-by: senthil <cendhu@gmail.com>