### PR TITLE
Add script to generate crypto materials to run single node

### DIFF
--- a/sampleconfig/1node-shared-config-bootstrap.yml
+++ b/sampleconfig/1node-shared-config-bootstrap.yml
@@ -1,4 +1,4 @@
-# 3node-shared-config-bootstrap.yml
+# 1node-shared-config-bootstrap.yml
 #
 # This file contains the the initial configuration that will be converted into the ledger's genesis block and
 # loaded into the database when the server starts with an empty ledger and database.
@@ -81,4 +81,4 @@ admin:
   id: admin
   # identity.certificatePath denotes the path
   # to the x509 certificate of the cluster admin
-  certificatePath: /etc/bcdb-server/pki/node/node.cert
+  certificatePath: /etc/bcdb-server/pki/admin/admin.cert

--- a/scripts/cryptoGen.sh
+++ b/scripts/cryptoGen.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+
+BASE_DIR=$1
+
+rm -rf "$BASE_DIR/pki"
+
+echo "Creating PKIs folders"
+mkdir -p "$BASE_DIR/pki/ca"
+
+echo "Generate root CA private key"
+openssl ecparam -name prime256v1 -genkey -noout -out "$BASE_DIR/pki/ca/rootCA.key"
+
+echo "Generating self-signed root CA certificate"
+openssl req -new -x509 -nodes -key "$BASE_DIR/pki/ca/rootCA.key" -sha256 -days 365 -out "$BASE_DIR/pki/ca/rootCA.cert" -subj "/C=IL/ST=Haifa/O=BCDB" -extensions v3_ca
+
+for f in "node" "admin" "user"
+do
+    echo "Creating PKIs folders"
+    mkdir -p "$BASE_DIR/pki/$f"
+
+    echo "Generating private key for $f"
+    openssl ecparam -name prime256v1 -genkey -noout -out "$BASE_DIR/pki/$f/$f.key"
+
+    echo "Generate node CSR"
+    openssl req -new -key "$BASE_DIR/pki/$f/$f.key" -out "$BASE_DIR/pki/$f/$f.csr" -subj "/C=IL/ST=Haifa/O=BCDB"
+
+    echo "Generate node certificate"
+    openssl x509 -req -in "$BASE_DIR/pki/$f/$f.csr" -CA "$BASE_DIR/pki/ca/rootCA.cert" -CAkey "$BASE_DIR/pki/ca/rootCA.key" -CAcreateserial -out "$BASE_DIR/pki/$f/$f.cert" -days 365 -sha256
+done


### PR DESCRIPTION
Now it's possible to run:

```
./scripts/cryptoGen.sh sampleconfig
```

given there is a docker image created with 

```
make docker
```

and next

```
docker run -it --rm -v $(pwd)/sampleconfig/:/etc/bcdb-server bcdb-container
```

will run the single instance of the BCDB

```
2021-07-02 22:27:45.607424 I | Starting a blockchain database
2021-07-02T22:27:45.699Z        INFO    bcdb-node1      bcdb/transaction_processor.go:97        Bootstrapping the ledger and database
2021-07-02T22:27:45.743Z        INFO    bcdb-node1      blockprocessor/processor.go:286 Registering listener [transactionProcessor]
2021-07-02T22:27:45.743Z        INFO    bcdb-node1      txreorderer/txreorderer.go:59   starting the transactions reorderer
2021-07-02T22:27:45.743Z        INFO    bcdb-node1      blockcreator/blockcreator.go:89 starting the block creator
2021-07-02T22:27:45.744Z        INFO    bcdb-node1      replication/blockreplicator.go:91       Starting the block replicator
2021-07-02T22:27:45.744Z        INFO    bcdb-node1      comm/httptransport.go:156       http transport starting to serve peers on: 127.0.0.1:7050
2021-07-02T22:27:45.746Z        INFO    bcdb-node1      server/server.go:80     Server starting at ledger height [1]
2021-07-02T22:27:45.747Z        INFO    bcdb-node1      server/server.go:89     Starting to serve requests on: 127.0.0.1:6001
```

Signed-off-by: Artem Barger <artem@bargr.net>