### PR TITLE
Fix missing return of the error in mptrie

### DIFF
--- a/internal/mptrie/mptrie.go
+++ b/internal/mptrie/mptrie.go
@@ -101,7 +101,7 @@ func (t *MPTrie) Update(key, value []byte) error {
 	defer t.lock.Unlock()
 
 	if len(key) == 0 {
-		errors.New("can't update element with empty key")
+		return errors.New("can't update element with empty key")
 	}
 	valuePtr, err := CalculateKeyValueHash(key, value)
 	if err != nil {

--- a/internal/mptrie/proof.go
+++ b/internal/mptrie/proof.go
@@ -22,7 +22,7 @@ func (t *MPTrie) GetProof(key []byte, isDeleted bool) (*Proof, error) {
 	hexKey := convertByteToHex(key)
 	path, node, err := t.getPath(hexKey)
 
-	if err != err {
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
One of the previous commits missed returning the error within Update API if the empty key was put as a parameter to the function call. 

Another issue is within `GetProof` the error was compared with itself, i.e.

```
	if err != err {
		return nil, err
	}
```

which obviously always false. This commit fixes it as well. 

Signed-off-by: Artem Barger <artem@bargr.net>