### PR TITLE
Use variable type while asserting within swith case

### DIFF
--- a/internal/mptrie/mptrie.go
+++ b/internal/mptrie/mptrie.go
@@ -117,13 +117,13 @@ func (t *MPTrie) Update(key, value []byte) error {
 }
 
 func (t *MPTrie) update(node TrieNode, hexKey, valuePtr []byte, isDeleted bool) (TrieNode, []byte, error) {
-	switch node.(type) {
+	switch node := node.(type) {
 	case *BranchNode:
-		return t.updateBranchNode(node.(*BranchNode), hexKey, valuePtr, isDeleted)
+		return t.updateBranchNode(node, hexKey, valuePtr, isDeleted)
 	case *ExtensionNode:
-		return t.updateExtensionNode(node.(*ExtensionNode), hexKey, valuePtr, isDeleted)
+		return t.updateExtensionNode(node, hexKey, valuePtr, isDeleted)
 	case *ValueNode:
-		return t.updateValueNode(node.(*ValueNode), hexKey, valuePtr, isDeleted)
+		return t.updateValueNode(node, hexKey, valuePtr, isDeleted)
 	case *EmptyNode:
 		return t.updateEmptyNode(hexKey, valuePtr)
 	default:
@@ -469,9 +469,9 @@ func (t *MPTrie) persistSubtrie(n TrieNode) error {
 	if !wasChanged {
 		return nil
 	}
-	switch n.(type) {
+	switch n := n.(type) {
 	case *BranchNode:
-		for _, childPtr := range n.(*BranchNode).Children {
+		for _, childPtr := range n.Children {
 			if childPtr != nil {
 				child, err := t.store.GetNode(childPtr)
 				if err != nil {
@@ -483,13 +483,13 @@ func (t *MPTrie) persistSubtrie(n TrieNode) error {
 				}
 			}
 		}
-		if n.(*BranchNode).ValuePtr != nil {
-			if _, err := t.store.PersistValue(n.(*BranchNode).ValuePtr); err != nil {
+		if n.ValuePtr != nil {
+			if _, err := t.store.PersistValue(n.ValuePtr); err != nil {
 				return err
 			}
 		}
 	case *ExtensionNode:
-		child, err := t.store.GetNode(n.(*ExtensionNode).Child)
+		child, err := t.store.GetNode(n.Child)
 		if err != nil {
 			return err
 		}
@@ -498,7 +498,7 @@ func (t *MPTrie) persistSubtrie(n TrieNode) error {
 			return err
 		}
 	case *ValueNode:
-		if _, err := t.store.PersistValue(n.(*ValueNode).ValuePtr); err != nil {
+		if _, err := t.store.PersistValue(n.ValuePtr); err != nil {
 			return err
 		}
 	default:

--- a/internal/mptrie/node.go
+++ b/internal/mptrie/node.go
@@ -24,9 +24,8 @@ func (m *BranchNode) hash() ([]byte, error) {
 
 func (m *BranchNode) bytes() [][]byte {
 	bytes := make([][]byte, 0)
-	for _, child := range m.Children {
-		bytes = append(bytes, child)
-	}
+	bytes = append(bytes, m.Children...)
+
 	if len(m.ValuePtr) > 0 {
 		bytes = append(bytes, m.ValuePtr)
 	}


### PR DESCRIPTION
Within the implementation of mptie there were a few nits, while using a switch to assert node type there is a way to leverage type knowledge to eliminate the need for casting variables later on. 

Signed-off-by: Artem Barger <artem@bargr.net>