### PR TITLE
Updating crypto material and docker image generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TIMEOUT  = 20m
 GO      = go
 DOCKER  = docker
-DOCKER_IMAGE = bcdb-container
+DOCKER_IMAGE = bcdb-server
 DOCKERFILE = images/Dockerfile
 PKGS     = $(or $(PKG),$(shell env GO111MODULE=on $(GO) list ./...))
 TESTPKGS = $(shell env GO111MODULE=on $(GO) list -f \

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -25,7 +25,6 @@ FROM bcdb-base
 VOLUME /etc/bcdb-server
 VOLUME /var/bcdb-server
 COPY --from=bcdb /go/src/github.com/IBM-Blockchain/bcdb-server/bin/bdb /usr/local/bin
-COPY --from=bcdb /go/src/github.com/IBM-Blockchain/bcdb-server/sampleconfig/config.yml /etc/bcdb-server
-COPY --from=bcdb /go/src/github.com/IBM-Blockchain/bcdb-server/sampleconfig/1node-shared-config-bootstrap.yml /etc/bcdb-server
+COPY --from=bcdb /go/src/github.com/IBM-Blockchain/bcdb-server/sampleconfig/ /etc/bcdb-server
 EXPOSE 6001
-CMD ["bdb", "start", "--configpath", "/etc/bcdb-server/."]
+CMD ["bdb", "start", "--configpath", "/etc/bcdb-server/config/."]

--- a/sampleconfig/config/1node-shared-config-bootstrap.yml
+++ b/sampleconfig/config/1node-shared-config-bootstrap.yml
@@ -14,7 +14,7 @@ nodes:
   - nodeId: bcdb-node1
     host: 127.0.0.1
     port: 6001
-    certificatePath: /etc/bcdb-server/pki/node/node.cert
+    certificatePath: /etc/bcdb-server/crypto/node/node.pem
 
 # consensus carries the definitions of the clustered consensus algorithm, members, and parameters.
 consensus:
@@ -70,7 +70,7 @@ consensus:
 caConfig:
   # The paths to root certificates. At least one is required. for example:
   #   rootCACertsPath: ./pki/rootcaA.cert, ./pki/rootcaB.cert
-  rootCACertsPath: /etc/bcdb-server/pki/ca/rootCA.cert
+  rootCACertsPath: /etc/bcdb-server/crypto/CA/CA.pem
 
   # The paths to intermediate certificates. Optional. For example:
   #   intermediateCACertsPath: ./pki/midcaA.cert, ./pki/midcaB.cert
@@ -81,4 +81,4 @@ admin:
   id: admin
   # identity.certificatePath denotes the path
   # to the x509 certificate of the cluster admin
-  certificatePath: /etc/bcdb-server/pki/admin/admin.cert
+  certificatePath: /etc/bcdb-server/crypto/admin/admin.pem

--- a/sampleconfig/config/config.yml
+++ b/sampleconfig/config/config.yml
@@ -8,9 +8,9 @@ server:
     # of the node. This certificate and associated key is used in all
     # client facing communication, as well as for signing blocks and
     # transaction replies.
-    certificatePath: /etc/bcdb-server/pki/node/node.cert
+    certificatePath: /etc/bcdb-server/crypto/node/node.pem
     # identity.keyPath denotes the path to the private key of the node.
-    keyPath: /etc/bcdb-server/pki/node/node.key
+    keyPath: /etc/bcdb-server/crypto/node/node.key
   # The listen address and port of the network interface used for client
   # communication. The external address (or host name) of this interface
   # must be accessible to clients, and is declared in:
@@ -19,7 +19,7 @@ server:
   # where consensus.members[i].nodeID == node.identity.id
   network:
     # network.address denotes the listen address
-    address: 127.0.0.1
+    address:
     # network.port denotes the listen port
     port: 6001
   database:
@@ -28,7 +28,7 @@ server:
     name: leveldb
     # database.ledgerDirectory denotes the root path
     # where we store all ledger data
-    ledgerDirectory: ledger
+    ledgerdirectory: /etc/bcdb-server/ledger
   queueLength:
     # queueLength.transaction denotes the maximum
     # queue length of waiting transactions
@@ -82,20 +82,20 @@ replication:
     # Require client certificates / mutual TLS for inbound connections.
     clientAuthRequired: false
     # X.509 certificate used for TLS server
-    serverCertificatePath: /etc/bcdb-server/pki/cluster/server.cert
+    serverCertificatePath: /etc/bcdb-server/crypto/cluster/server.cert
     # Private key for TLS server
-    serverKeyPath: /etc/bcdb-server/pki/cluster/server.key
+    serverKeyPath: /etc/bcdb-server/crypto/cluster/server.key
     # X.509 certificate used for creating TLS client connections.
-    clientCertificatePath: /etc/bcdb-server/pki/cluster/client.cert
+    clientCertificatePath: /etc/bcdb-server/crypto/cluster/client.cert
     # Private key used for creating TLS client connections.
-    clientKeyPath: /etc/bcdb-server/pki/cluster/client.key
+    clientKeyPath: /etc/bcdb-server/crypto/cluster/client.key
     # cluster.tls.caConfig defines the paths to the x509 certificates
     # of the root and intermediate certificate authorities that issued
     # all the certificates used for intra-cluster communication.
     caConfig:
       # The paths to root certificates. At least one is required. for example:
       #   rootCACertsPath: ./testdata/rootcaA.cert, ./testdata/rootcaB.cert
-      rootCACertsPath: /etc/bcdb-server/pki/cluster/rootca.cert
+      rootCACertsPath: /etc/bcdb-server/crypto/cluster/rootca.cert
 
       # The paths to intermediate certificates. Optional. For example:
       # intermediateCACertsPath: ./testdata/cluster/midcaA.cert, ./testdata/cluster/midcaB.cert
@@ -111,4 +111,4 @@ bootstrap:
   #    and on-board by fetching the ledger from them, rebuilding the database in the process (not supported yet).
   method: genesis
   # file contains the initial configuration that will be used to bootstrap the node, as specified by the method, above.
-  file: /etc/bcdb-server/1node-shared-config-bootstrap.yml
+  file: /etc/bcdb-server/config/1node-shared-config-bootstrap.yml


### PR DESCRIPTION
Crypto materials and configuration folders structure changed to folder structure used by car demo application
Crypto generation now done by dockerized openssl - see cryptoGen.sh

To create minimal crypto configuration, you can run:
```
./scripts/cryptoGen.sh sampleconfig
```
To create crypto configuration for more users/server, you can run:
```
./scripts/cryptoGen.sh sampleconfig <extra users>
```
For example, in case you want to generate crypto materials for extra users used in car demo, you can run:
```
./scripts/cryptoGen.sh sampleconfig alice bob dmv dealer
```

To generate docker image, after you generated crypto materials, run:
```
make docker
```

To invoke bcdb docker container, you can run:
```
docker run -it --rm -v $(pwd)/sampleconfig/:/etc/bcdb-server -p 6001:6001 -p 7050:7050 bcdb-server
``` 

Signed-off-by: Gennady Laventman <gennady@il.ibm.com>