### PR TITLE
fix dbupdates

### DIFF
--- a/internal/bcdb/transaction_processor_test.go
+++ b/internal/bcdb/transaction_processor_test.go
@@ -185,9 +185,8 @@ func setupTxProcessor(t *testing.T, env *txProcessorTestEnv, dbName string) {
 	u, err := proto.Marshal(user)
 	require.NoError(t, err)
 
-	createUser := []*worldstate.DBUpdates{
-		{
-			DBName: worldstate.UsersDBName,
+	createUser := map[string]*worldstate.DBUpdates{
+		worldstate.UsersDBName: {
 			Writes: []*worldstate.KVWithMetadata{
 				{
 					Key:   string(identity.UserNamespace) + env.userID,
@@ -704,9 +703,9 @@ func applyTxsOnTrie(t *testing.T, env *txProcessorTestEnv, payload interface{}, 
 	dbUpdates, err := blockprocessor.ConstructDBUpdatesForBlock(tempBlock, env.txProcessor.blockProcessor)
 	require.NoError(t, err)
 
-	for _, update := range dbUpdates {
+	for dbName, update := range dbUpdates {
 		for _, dbwrite := range update.Writes {
-			key, err := mptrie.ConstructCompositeKey(update.DBName, dbwrite.Key)
+			key, err := mptrie.ConstructCompositeKey(dbName, dbwrite.Key)
 			require.NoError(t, err)
 			// TODO: should we add Metadata to value
 			value := dbwrite.Value
@@ -714,7 +713,7 @@ func applyTxsOnTrie(t *testing.T, env *txProcessorTestEnv, payload interface{}, 
 			require.NoError(t, err)
 		}
 		for _, dbdelete := range update.Deletes {
-			key, err := mptrie.ConstructCompositeKey(update.DBName, dbdelete)
+			key, err := mptrie.ConstructCompositeKey(dbName, dbdelete)
 			require.NoError(t, err)
 			_, err = stateTrie.Delete(key)
 			require.NoError(t, err)

--- a/internal/bcdb/worldstate_query_processor_test.go
+++ b/internal/bcdb/worldstate_query_processor_test.go
@@ -84,9 +84,8 @@ func TestGetDBStatus(t *testing.T) {
 		env := newWorldstateQueryProcessorTestEnv(t)
 		defer env.cleanup(t)
 
-		createDB := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.DatabasesDBName,
+		createDB := map[string]*worldstate.DBUpdates{
+			worldstate.DatabasesDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key: "test-db",
@@ -135,9 +134,8 @@ func TestGetData(t *testing.T) {
 		u, err := proto.Marshal(user)
 		require.NoError(t, err)
 
-		createUser := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.UsersDBName,
+		createUser := map[string]*worldstate.DBUpdates{
+			worldstate.UsersDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:   string(identity.UserNamespace) + userID,
@@ -154,9 +152,8 @@ func TestGetData(t *testing.T) {
 		}
 		require.NoError(t, db.Commit(createUser, 2))
 
-		createDB := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.DatabasesDBName,
+		createDB := map[string]*worldstate.DBUpdates{
+			worldstate.DatabasesDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key: dbName,
@@ -194,9 +191,8 @@ func TestGetData(t *testing.T) {
 			},
 		}
 
-		dbsUpdates := []*worldstate.DBUpdates{
-			{
-				DBName: "test-db",
+		dbsUpdates := map[string]*worldstate.DBUpdates{
+			"test-db": {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:      "key1",
@@ -267,9 +263,8 @@ func TestGetData(t *testing.T) {
 			},
 		}
 
-		dbsUpdates := []*worldstate.DBUpdates{
-			{
-				DBName: "test-db",
+		dbsUpdates := map[string]*worldstate.DBUpdates{
+			"test-db": {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:      "key1",
@@ -394,9 +389,8 @@ func TestGetUser(t *testing.T) {
 			{
 				name: "querierUser has read permission on targetUser",
 				setup: func(db worldstate.DB) {
-					addUser := []*worldstate.DBUpdates{
-						{
-							DBName: worldstate.UsersDBName,
+					addUser := map[string]*worldstate.DBUpdates{
+						worldstate.UsersDBName: {
 							Writes: []*worldstate.KVWithMetadata{
 								{
 									Key:   string(identity.UserNamespace) + "querierUser",
@@ -423,9 +417,8 @@ func TestGetUser(t *testing.T) {
 			{
 				name: "querierUser has read-write permission on targetUser",
 				setup: func(db worldstate.DB) {
-					addUser := []*worldstate.DBUpdates{
-						{
-							DBName: worldstate.UsersDBName,
+					addUser := map[string]*worldstate.DBUpdates{
+						worldstate.UsersDBName: {
 							Writes: []*worldstate.KVWithMetadata{
 								{
 									Key:   string(identity.UserNamespace) + "querierUser",
@@ -452,9 +445,8 @@ func TestGetUser(t *testing.T) {
 			{
 				name: "target user has no ACL",
 				setup: func(db worldstate.DB) {
-					addUser := []*worldstate.DBUpdates{
-						{
-							DBName: worldstate.UsersDBName,
+					addUser := map[string]*worldstate.DBUpdates{
+						worldstate.UsersDBName: {
 							Writes: []*worldstate.KVWithMetadata{
 								{
 									Key:   string(identity.UserNamespace) + "querierUser",
@@ -481,9 +473,8 @@ func TestGetUser(t *testing.T) {
 			{
 				name: "target user does not exist",
 				setup: func(db worldstate.DB) {
-					addUser := []*worldstate.DBUpdates{
-						{
-							DBName: worldstate.UsersDBName,
+					addUser := map[string]*worldstate.DBUpdates{
+						worldstate.UsersDBName: {
 							Writes: []*worldstate.KVWithMetadata{
 								{
 									Key:   string(identity.UserNamespace) + "querierUser",
@@ -562,9 +553,8 @@ func TestGetUser(t *testing.T) {
 			{
 				name: "querierUser has no read permission on the target user",
 				setup: func(db worldstate.DB) {
-					addUser := []*worldstate.DBUpdates{
-						{
-							DBName: worldstate.UsersDBName,
+					addUser := map[string]*worldstate.DBUpdates{
+						worldstate.UsersDBName: {
 							Writes: []*worldstate.KVWithMetadata{
 								{
 									Key:   string(identity.UserNamespace) + "querierUser",
@@ -648,9 +638,8 @@ func TestGetConfig(t *testing.T) {
 			},
 		}
 
-		dbUpdates := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.ConfigDBName,
+		dbUpdates := map[string]*worldstate.DBUpdates{
+			worldstate.ConfigDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:      worldstate.ConfigKey,
@@ -668,7 +657,8 @@ func TestGetConfig(t *testing.T) {
 				TxNum:    5,
 			},
 		)
-		dbUpdates = append(dbUpdates, dbUpdate)
+		dbUpdates[worldstate.ConfigDBName].Writes = append(dbUpdates[worldstate.ConfigDBName].Writes, dbUpdate.Writes...)
+		dbUpdates[worldstate.ConfigDBName].Deletes = append(dbUpdates[worldstate.ConfigDBName].Deletes, dbUpdate.Deletes...)
 		require.NoError(t, env.db.Commit(dbUpdates, 1))
 
 		configEnvelope, err := env.q.getConfig()
@@ -692,9 +682,8 @@ func TestGetConfig(t *testing.T) {
 			},
 		}
 
-		dbUpdates := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.ConfigDBName,
+		dbUpdates := map[string]*worldstate.DBUpdates{
+			worldstate.ConfigDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:      worldstate.ConfigKey,
@@ -752,9 +741,8 @@ func TestGetConfig(t *testing.T) {
 			},
 		}
 
-		dbUpdates := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.ConfigDBName,
+		dbUpdates := map[string]*worldstate.DBUpdates{
+			worldstate.ConfigDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:      worldstate.ConfigKey,
@@ -772,7 +760,8 @@ func TestGetConfig(t *testing.T) {
 				TxNum:    5,
 			},
 		)
-		dbUpdates = append(dbUpdates, dbUpdate)
+		dbUpdates[worldstate.ConfigDBName].Writes = append(dbUpdates[worldstate.ConfigDBName].Writes, dbUpdate.Writes...)
+		dbUpdates[worldstate.ConfigDBName].Deletes = append(dbUpdates[worldstate.ConfigDBName].Deletes, dbUpdate.Deletes...)
 		require.NoError(t, env.db.Commit(dbUpdates, 1))
 
 		singleNodeConfigEnvelope, err := env.q.getNodeConfig("node1")

--- a/internal/blockprocessor/config_tx_validator_test.go
+++ b/internal/blockprocessor/config_tx_validator_test.go
@@ -44,9 +44,8 @@ func TestValidateConfigTx(t *testing.T) {
 		adminUserSerialized, err := proto.Marshal(adminUser)
 		require.NoError(t, err)
 
-		newUsers := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.UsersDBName,
+		newUsers := map[string]*worldstate.DBUpdates{
+			worldstate.UsersDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:   string(identity.UserNamespace) + "nonAdminUser",
@@ -1172,9 +1171,8 @@ func TestMVCCOnConfigTx(t *testing.T) {
 		{
 			name: "invalid: readVersion does not match committed version",
 			setup: func(db worldstate.DB) {
-				config := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.ConfigDBName,
+				config := map[string]*worldstate.DBUpdates{
+					worldstate.ConfigDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: worldstate.ConfigKey,
@@ -1203,9 +1201,8 @@ func TestMVCCOnConfigTx(t *testing.T) {
 		{
 			name: "valid as the read and committed version are the same",
 			setup: func(db worldstate.DB) {
-				config := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.ConfigDBName,
+				config := map[string]*worldstate.DBUpdates{
+					worldstate.ConfigDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: worldstate.ConfigKey,

--- a/internal/blockprocessor/data_tx_validator_test.go
+++ b/internal/blockprocessor/data_tx_validator_test.go
@@ -51,9 +51,8 @@ func TestValidateDataTx(t *testing.T) {
 		bobSerialized, err := proto.Marshal(b)
 		require.NoError(t, err)
 
-		userAdd := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.UsersDBName,
+		userAdd := map[string]*worldstate.DBUpdates{
+			worldstate.UsersDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:   string(identity.UserNamespace) + alice,
@@ -166,9 +165,8 @@ func TestValidateDataTx(t *testing.T) {
 		{
 			name: "Invalid signature from must sign user",
 			setup: func(db worldstate.DB) {
-				user := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				user := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, alice, bogusCert.Raw, nil, nil, nil),
 							constructUserForTest(t, bob, bobCert.Raw, nil, nil, nil),
@@ -203,9 +201,8 @@ func TestValidateDataTx(t *testing.T) {
 		{
 			name: "Invalid signature from non-must sign user and bob does not have rw access on the db",
 			setup: func(db worldstate.DB) {
-				user := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				user := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, alice, bogusCert.Raw, nil, nil, nil),
 							constructUserForTest(t, bob, bobCert.Raw, nil, nil, nil),
@@ -232,9 +229,8 @@ func TestValidateDataTx(t *testing.T) {
 		{
 			name: "Invalid signature from non-must sign user but the transaction would be marked valid",
 			setup: func(db worldstate.DB) {
-				user := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				user := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, alice, bogusCert.Raw, nil, nil, nil),
 							constructUserForTest(t, bob, bobCert.Raw, &types.Privilege{
@@ -264,9 +260,8 @@ func TestValidateDataTx(t *testing.T) {
 		{
 			name: "invalid: duplicate database entry in operations",
 			setup: func(db worldstate.DB) {
-				user := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				user := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, alice, aliceCert.Raw, nil, nil, nil),
 							constructUserForTest(t, bob, bobCert.Raw, nil, nil, nil),
@@ -306,9 +301,8 @@ func TestValidateDataTx(t *testing.T) {
 		{
 			name: "invalid: user does not have rw permission on the db1",
 			setup: func(db worldstate.DB) {
-				user := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				user := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, alice, aliceCert.Raw, nil, nil, nil),
 							constructUserForTest(t, bob, bobCert.Raw, nil, nil, nil),
@@ -400,9 +394,8 @@ func TestValidateDataTx(t *testing.T) {
 			setup: func(db worldstate.DB) {
 				addUserWithCorrectPrivilege(db)
 
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -448,9 +441,8 @@ func TestValidateDataTx(t *testing.T) {
 			setup: func(db worldstate.DB) {
 				addUserWithCorrectPrivilege(db)
 
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -492,9 +484,8 @@ func TestValidateDataTx(t *testing.T) {
 			setup: func(db worldstate.DB) {
 				addUserWithCorrectPrivilege(db)
 
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -536,9 +527,8 @@ func TestValidateDataTx(t *testing.T) {
 			setup: func(db worldstate.DB) {
 				addUserWithCorrectPrivilege(db)
 
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -634,9 +624,8 @@ func TestValidateDataTx(t *testing.T) {
 			name: "valid (has extra sign)",
 			setup: func(db worldstate.DB) {
 				addUserWithCorrectPrivilege(db)
-				db1 := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DatabasesDBName,
+				db1 := map[string]*worldstate.DBUpdates{
+					worldstate.DatabasesDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "db1",
@@ -652,9 +641,8 @@ func TestValidateDataTx(t *testing.T) {
 				}
 				require.NoError(t, db.Commit(db1, 1))
 
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -686,8 +674,7 @@ func TestValidateDataTx(t *testing.T) {
 							},
 						},
 					},
-					{
-						DBName: "db1",
+					"db1": {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key3",
@@ -783,9 +770,8 @@ func TestValidateDataTx(t *testing.T) {
 			name: "valid (mix of write policy)",
 			setup: func(db worldstate.DB) {
 				addUserWithCorrectPrivilege(db)
-				db1 := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DatabasesDBName,
+				db1 := map[string]*worldstate.DBUpdates{
+					worldstate.DatabasesDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "db1",
@@ -801,9 +787,8 @@ func TestValidateDataTx(t *testing.T) {
 				}
 				require.NoError(t, db.Commit(db1, 1))
 
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -839,8 +824,7 @@ func TestValidateDataTx(t *testing.T) {
 							},
 						},
 					},
-					{
-						DBName: "db1",
+					"db1": {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key3",
@@ -941,9 +925,8 @@ func TestValidateDataTx(t *testing.T) {
 			setup: func(db worldstate.DB) {
 				addUserWithCorrectPrivilege(db)
 
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1092,9 +1075,8 @@ func TestValidateFieldsInDataWrites(t *testing.T) {
 		{
 			name: "valid",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, "user1", nil, nil, nil, nil),
 							constructUserForTest(t, "user2", nil, nil, nil, nil),
@@ -1208,9 +1190,8 @@ func TestValidateFieldsInDataDeletes(t *testing.T) {
 		{
 			name: "valid",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1359,9 +1340,8 @@ func TestValidateAClOnDataReads(t *testing.T) {
 		{
 			name: "invalid: user does not have the permission",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1394,9 +1374,8 @@ func TestValidateAClOnDataReads(t *testing.T) {
 		{
 			name: "valid: acl check passes as the user has read permission",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1428,9 +1407,8 @@ func TestValidateAClOnDataReads(t *testing.T) {
 		{
 			name: "valid: acl check passes as the user has read-write permission itself",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1462,9 +1440,8 @@ func TestValidateAClOnDataReads(t *testing.T) {
 		{
 			name: "valid: no acl",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1534,9 +1511,8 @@ func TestValidateAClOnDataWrites(t *testing.T) {
 		{
 			name: "invalid: user does not have the permission - ANY write policy",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1570,9 +1546,8 @@ func TestValidateAClOnDataWrites(t *testing.T) {
 		{
 			name: "invalid: user does not have the permission - ALL write policy",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1608,9 +1583,8 @@ func TestValidateAClOnDataWrites(t *testing.T) {
 		{
 			name: "invalid: no user has permission to modify read-only key",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1643,9 +1617,8 @@ func TestValidateAClOnDataWrites(t *testing.T) {
 		{
 			name: "valid: acl check passes - ANY write policy",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1679,9 +1652,8 @@ func TestValidateAClOnDataWrites(t *testing.T) {
 		{
 			name: "valid: acl check passes - ALL write policy",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1715,9 +1687,8 @@ func TestValidateAClOnDataWrites(t *testing.T) {
 		{
 			name: "valid: no acl",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1787,9 +1758,8 @@ func TestValidateAClOnDataDeletes(t *testing.T) {
 		{
 			name: "invalid: user does not have the permission - ANY write policy",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1823,9 +1793,8 @@ func TestValidateAClOnDataDeletes(t *testing.T) {
 		{
 			name: "invalid: user does not have the permission - ALL write policy",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1861,9 +1830,8 @@ func TestValidateAClOnDataDeletes(t *testing.T) {
 		{
 			name: "invalid: no user has permission to modify read-only key",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1896,9 +1864,8 @@ func TestValidateAClOnDataDeletes(t *testing.T) {
 		{
 			name: "valid: acl check passes - ANY write policy",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1932,9 +1899,8 @@ func TestValidateAClOnDataDeletes(t *testing.T) {
 		{
 			name: "valid: acl check passes - ALL write policy",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -1968,9 +1934,8 @@ func TestValidateAClOnDataDeletes(t *testing.T) {
 		{
 			name: "valid: no acl",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -2105,9 +2070,8 @@ func TestMVCCOnDataTx(t *testing.T) {
 		{
 			name: "invalid: committed version does not match the read version",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -2146,9 +2110,8 @@ func TestMVCCOnDataTx(t *testing.T) {
 		{
 			name: "valid",
 			setup: func(db worldstate.DB) {
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",

--- a/internal/blockprocessor/dbadmin_tx_validator_test.go
+++ b/internal/blockprocessor/dbadmin_tx_validator_test.go
@@ -34,9 +34,8 @@ func TestValidateDBAdminTx(t *testing.T) {
 	userWithLessPrivilegeSerialized, err := proto.Marshal(userWithLessPrivilege)
 	require.NoError(t, err)
 
-	underPrivilegedUser := []*worldstate.DBUpdates{
-		{
-			DBName: worldstate.UsersDBName,
+	underPrivilegedUser := map[string]*worldstate.DBUpdates{
+		worldstate.UsersDBName: {
 			Writes: []*worldstate.KVWithMetadata{
 				{
 					Key:      string(identity.UserNamespace) + "userWithLessPrivilege",
@@ -57,9 +56,8 @@ func TestValidateDBAdminTx(t *testing.T) {
 	userWithMorePrivilegeSerialized, err := proto.Marshal(userWithMorePrivilege)
 	require.NoError(t, err)
 
-	privilegedUser := []*worldstate.DBUpdates{
-		{
-			DBName: worldstate.UsersDBName,
+	privilegedUser := map[string]*worldstate.DBUpdates{
+		worldstate.UsersDBName: {
 			Writes: []*worldstate.KVWithMetadata{
 				{
 					Key:      string(identity.UserNamespace) + "userWithMorePrivilege",
@@ -189,9 +187,8 @@ func TestValidateDBAdminTx(t *testing.T) {
 			setup: func(db worldstate.DB) {
 				require.NoError(t, db.Commit(privilegedUser, 1))
 
-				createDB := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DatabasesDBName,
+				createDB := map[string]*worldstate.DBUpdates{
+					worldstate.DatabasesDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "db3",
@@ -276,9 +273,8 @@ func TestValidateCreateDBEntries(t *testing.T) {
 			name:        "invalid: existing database cannot be created",
 			toCreateDBs: []string{"db1"},
 			setup: func(db worldstate.DB) {
-				createDB := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DatabasesDBName,
+				createDB := map[string]*worldstate.DBUpdates{
+					worldstate.DatabasesDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "db1",
@@ -371,9 +367,8 @@ func TestValidateDeleteDBEntries(t *testing.T) {
 		{
 			name: "invalid: database is duplicated in the delete list",
 			setup: func(db worldstate.DB) {
-				createDB := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DatabasesDBName,
+				createDB := map[string]*worldstate.DBUpdates{
+					worldstate.DatabasesDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "db1",
@@ -392,9 +387,8 @@ func TestValidateDeleteDBEntries(t *testing.T) {
 		{
 			name: "valid",
 			setup: func(db worldstate.DB) {
-				createDB := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DatabasesDBName,
+				createDB := map[string]*worldstate.DBUpdates{
+					worldstate.DatabasesDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "db1",
@@ -475,9 +469,8 @@ func TestValidateIndexDBEntries(t *testing.T) {
 		{
 			name: "invalid: db exist but appears in the deleteDB list too",
 			setup: func(db worldstate.DB) {
-				createDB := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DatabasesDBName,
+				createDB := map[string]*worldstate.DBUpdates{
+					worldstate.DatabasesDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "db1",

--- a/internal/blockprocessor/processor_test.go
+++ b/internal/blockprocessor/processor_test.go
@@ -256,9 +256,8 @@ func setup(t *testing.T, env *testEnv) {
 	u, err := proto.Marshal(user)
 	require.NoError(t, err)
 
-	createUser := []*worldstate.DBUpdates{
-		{
-			DBName: worldstate.UsersDBName,
+	createUser := map[string]*worldstate.DBUpdates{
+		worldstate.UsersDBName: {
 			Writes: []*worldstate.KVWithMetadata{
 				{
 					Key:   string(identity.UserNamespace) + env.userID,

--- a/internal/blockprocessor/test_util.go
+++ b/internal/blockprocessor/test_util.go
@@ -5,7 +5,7 @@ import (
 	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
 )
 
-func ConstructDBUpdatesForBlock(block *types.Block, bp *BlockProcessor) ([]*worldstate.DBUpdates, error) {
+func ConstructDBUpdatesForBlock(block *types.Block, bp *BlockProcessor) (map[string]*worldstate.DBUpdates, error) {
 	dbsUpdates, _, err := bp.committer.constructDBAndProvenanceEntries(block)
 	if err != nil {
 		return nil, err

--- a/internal/blockprocessor/useradmin_tx_validator_test.go
+++ b/internal/blockprocessor/useradmin_tx_validator_test.go
@@ -54,9 +54,8 @@ func TestValidateUsedAdminTx(t *testing.T) {
 		{
 			name: "invalid: signature verification failure",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key:   string(identity.UserNamespace) + "adminUser",
@@ -87,9 +86,8 @@ func TestValidateUsedAdminTx(t *testing.T) {
 		{
 			name: "invalid: submitter does not have user admin privilege",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key:   string(identity.UserNamespace) + "nonAdminUser",
@@ -113,9 +111,8 @@ func TestValidateUsedAdminTx(t *testing.T) {
 		{
 			name: "invalid: userID in the write list is empty",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key:   string(identity.UserNamespace) + "adminUser",
@@ -146,9 +143,8 @@ func TestValidateUsedAdminTx(t *testing.T) {
 		{
 			name: "invalid: userID in the delete list is empty",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key:   string(identity.UserNamespace) + "adminUser",
@@ -177,9 +173,8 @@ func TestValidateUsedAdminTx(t *testing.T) {
 		{
 			name: "invalid: duplicate userID in the delete list",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key:   string(identity.UserNamespace) + "adminUser",
@@ -211,9 +206,8 @@ func TestValidateUsedAdminTx(t *testing.T) {
 		{
 			name: "invalid: acl on reads does not pass",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key:   string(identity.UserNamespace) + "adminUser",
@@ -247,9 +241,8 @@ func TestValidateUsedAdminTx(t *testing.T) {
 		{
 			name: "invalid: acl on write does not pass",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key:   string(identity.UserNamespace) + "adminUser",
@@ -286,9 +279,8 @@ func TestValidateUsedAdminTx(t *testing.T) {
 		{
 			name: "invalid: acl on deletes does not pass",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key:   string(identity.UserNamespace) + "adminUser",
@@ -322,9 +314,8 @@ func TestValidateUsedAdminTx(t *testing.T) {
 		{
 			name: "invalid: mvcc validation does not pass",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key:   string(identity.UserNamespace) + "adminUser",
@@ -362,9 +353,8 @@ func TestValidateUsedAdminTx(t *testing.T) {
 		{
 			name: "valid",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key:   string(identity.UserNamespace) + "adminUser",
@@ -768,9 +758,8 @@ func TestValidateACLOnUserReads(t *testing.T) {
 			name:          "invalid: operatingUser does not have read permission on user2",
 			operatingUser: "operatingUser",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, "operatingUser", nil, nil, sampleVersion, nil),
 							constructUserForTest(t, "user1", nil, nil, sampleVersion, &types.AccessControl{
@@ -805,9 +794,8 @@ func TestValidateACLOnUserReads(t *testing.T) {
 			name:          "valid: acl check passes",
 			operatingUser: "operatingUser",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, "operatingUser", nil, nil, sampleVersion, nil),
 							constructUserForTest(t, "user1", nil, nil, sampleVersion, &types.AccessControl{
@@ -900,9 +888,8 @@ func TestValidateACLOnUserWrites(t *testing.T) {
 			name:          "invalid: targetUser is an admin",
 			operatingUser: "operatingUser",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, "operatingUser", nil, nil, sampleVersion, nil),
 							adminEntry,
@@ -927,9 +914,8 @@ func TestValidateACLOnUserWrites(t *testing.T) {
 			name:          "invalid: operatingUser does not have write permission on user2",
 			operatingUser: "operatingUser",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, "operatingUser", nil, nil, sampleVersion, nil),
 							constructUserForTest(t, "user1", nil, nil, sampleVersion, &types.AccessControl{
@@ -968,9 +954,8 @@ func TestValidateACLOnUserWrites(t *testing.T) {
 			name:          "valid: acl check passes",
 			operatingUser: "operatingUser",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, "operatingUser", nil, nil, sampleVersion, nil),
 							constructUserForTest(t, "user1", nil, nil, sampleVersion, &types.AccessControl{
@@ -1071,9 +1056,8 @@ func TestValidateACLOnUserDeletes(t *testing.T) {
 			name:          "invalid: targetUser is an admin",
 			operatingUser: "operatingUser",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, "operatingUser", nil, nil, sampleVersion, nil),
 							adminEntry,
@@ -1096,9 +1080,8 @@ func TestValidateACLOnUserDeletes(t *testing.T) {
 			name:          "invalid: operatingUser does not have write permission on user2",
 			operatingUser: "operatingUser",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, "operatingUser", nil, nil, sampleVersion, nil),
 							constructUserForTest(t, "user1", nil, nil, sampleVersion, &types.AccessControl{
@@ -1133,9 +1116,8 @@ func TestValidateACLOnUserDeletes(t *testing.T) {
 			name:          "invalid: user2 present in the delete list does not exist",
 			operatingUser: "operatingUser",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, "operatingUser", nil, nil, sampleVersion, nil),
 							constructUserForTest(t, "user1", nil, nil, sampleVersion, &types.AccessControl{
@@ -1165,9 +1147,8 @@ func TestValidateACLOnUserDeletes(t *testing.T) {
 			name:          "valid: acl check passes",
 			operatingUser: "operatingUser",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, "operatingUser", nil, nil, sampleVersion, nil),
 							constructUserForTest(t, "user1", nil, nil, sampleVersion, &types.AccessControl{
@@ -1252,9 +1233,8 @@ func TestMVCCOnUserAdminTx(t *testing.T) {
 		{
 			name: "invalid: no committed state for user2",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, "user1", nil, nil, version1, nil),
 						},
@@ -1280,9 +1260,8 @@ func TestMVCCOnUserAdminTx(t *testing.T) {
 		{
 			name: "invalid: committed state does not match",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, "user1", nil, nil, version1, nil),
 							constructUserForTest(t, "user2", nil, nil, version3, nil),
@@ -1309,9 +1288,8 @@ func TestMVCCOnUserAdminTx(t *testing.T) {
 		{
 			name: "valid: reads matches committed version",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							constructUserForTest(t, "user1", nil, nil, version1, nil),
 							constructUserForTest(t, "user2", nil, nil, version3, nil),
@@ -1381,9 +1359,8 @@ func setupClusterConfigCA(t *testing.T, env *validatorTestEnv, rootCACert *x509.
 	}
 	configSerialized, err := proto.Marshal(config)
 	require.NoError(t, err)
-	newConfig := []*worldstate.DBUpdates{
-		{
-			DBName: worldstate.ConfigDBName,
+	newConfig := map[string]*worldstate.DBUpdates{
+		worldstate.ConfigDBName: {
 			Writes: []*worldstate.KVWithMetadata{
 				{
 					Key:   worldstate.ConfigKey,

--- a/internal/blockprocessor/validator_test.go
+++ b/internal/blockprocessor/validator_test.go
@@ -372,9 +372,8 @@ func TestValidateDataBlock(t *testing.T) {
 		userSerialized, err := proto.Marshal(user)
 		require.NoError(t, err)
 
-		userAdd := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.UsersDBName,
+		userAdd := map[string]*worldstate.DBUpdates{
+			worldstate.UsersDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:   string(identity.UserNamespace) + "operatingUser",
@@ -397,9 +396,8 @@ func TestValidateDataBlock(t *testing.T) {
 			name: "data block with valid and invalid transactions",
 			setup: func(db worldstate.DB) {
 				addUserWithCorrectPrivilege(db)
-				db1 := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DatabasesDBName,
+				db1 := map[string]*worldstate.DBUpdates{
+					worldstate.DatabasesDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "db1",
@@ -415,9 +413,8 @@ func TestValidateDataBlock(t *testing.T) {
 				}
 				require.NoError(t, db.Commit(db1, 1))
 
-				data := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.DefaultDBName,
+				data := map[string]*worldstate.DBUpdates{
+					worldstate.DefaultDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -449,8 +446,7 @@ func TestValidateDataBlock(t *testing.T) {
 							},
 						},
 					},
-					{
-						DBName: "db1",
+					"db1": {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key: "key1",
@@ -654,9 +650,8 @@ func TestValidateUserBlock(t *testing.T) {
 		{
 			name: "user block with an invalid transaction",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key:   string(identity.UserNamespace) + "adminUser",
@@ -706,9 +701,8 @@ func TestValidateUserBlock(t *testing.T) {
 		{
 			name: "user block with an valid transaction",
 			setup: func(db worldstate.DB) {
-				newUsers := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				newUsers := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key:   string(identity.UserNamespace) + "adminUser",
@@ -784,9 +778,8 @@ func TestValidateDBBlock(t *testing.T) {
 		userWithMorePrivilegeSerialized, err := proto.Marshal(userWithMorePrivilege)
 		require.NoError(t, err)
 
-		privilegedUser := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.UsersDBName,
+		privilegedUser := map[string]*worldstate.DBUpdates{
+			worldstate.UsersDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:   string(identity.UserNamespace) + "userWithMorePrivilege",
@@ -803,9 +796,8 @@ func TestValidateDBBlock(t *testing.T) {
 		}
 		require.NoError(t, db.Commit(privilegedUser, 1))
 
-		dbs := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.DatabasesDBName,
+		dbs := map[string]*worldstate.DBUpdates{
+			worldstate.DatabasesDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key: "db3",
@@ -909,9 +901,8 @@ func TestValidateConfigBlock(t *testing.T) {
 		adminUserSerialized, err := proto.Marshal(adminUser)
 		require.NoError(t, err)
 
-		newUsers := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.UsersDBName,
+		newUsers := map[string]*worldstate.DBUpdates{
+			worldstate.UsersDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:   string(identity.UserNamespace) + "adminUser",

--- a/internal/identity/db_entries.go
+++ b/internal/identity/db_entries.go
@@ -47,7 +47,6 @@ func ConstructDBEntriesForUserAdminTx(tx *types.UserAdministrationTx, version *t
 	}
 
 	return &worldstate.DBUpdates{
-		DBName:  worldstate.UsersDBName,
 		Writes:  userWrites,
 		Deletes: userDeletes,
 	}, nil
@@ -171,7 +170,6 @@ func ConstructDBEntriesForClusterAdmins(oldAdmins, newAdmins []*types.Admin, ver
 	}
 
 	return &worldstate.DBUpdates{
-		DBName:  worldstate.UsersDBName,
 		Writes:  kvWrites,
 		Deletes: deletes,
 	}, nil
@@ -277,7 +275,6 @@ func ConstructDBEntriesForNodes(oldNodes, newNodes []*types.NodeConfig, version 
 	}
 
 	return &worldstate.DBUpdates{
-		DBName:  worldstate.ConfigDBName,
 		Writes:  kvWrites,
 		Deletes: deletes,
 	}, nil

--- a/internal/identity/db_entries_test.go
+++ b/internal/identity/db_entries_test.go
@@ -60,7 +60,6 @@ func TestConstructDBEntriesForUserAdminTx(t *testing.T) {
 				TxNum:    5,
 			},
 			expectedDBUpdates: &worldstate.DBUpdates{
-				DBName: worldstate.UsersDBName,
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:   string(UserNamespace) + "user1",
@@ -100,7 +99,6 @@ func TestConstructDBEntriesForUserAdminTx(t *testing.T) {
 			},
 			version: nil,
 			expectedDBUpdates: &worldstate.DBUpdates{
-				DBName: worldstate.UsersDBName,
 				Writes: nil,
 				Deletes: []string{
 					string(UserNamespace) + "user3",
@@ -133,7 +131,6 @@ func TestConstructDBEntriesForUserAdminTx(t *testing.T) {
 				TxNum:    2,
 			},
 			expectedDBUpdates: &worldstate.DBUpdates{
-				DBName: worldstate.UsersDBName,
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:   string(UserNamespace) + "user1",
@@ -262,7 +259,6 @@ func TestConstructDBEntriesForClusterAdmins(t *testing.T) {
 			},
 			version: sampleVersion,
 			expectedUpdates: &worldstate.DBUpdates{
-				DBName: worldstate.UsersDBName,
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:   string(UserNamespace) + "admin3",
@@ -315,7 +311,6 @@ func TestConstructDBEntriesForClusterAdmins(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tt.expectedUpdates.DBName, updates.DBName)
 			require.Equal(t, tt.expectedUpdates.Deletes, updates.Deletes)
 
 			expectedWrites := make(map[string]*worldstate.KVWithMetadata)
@@ -446,9 +441,8 @@ func TestConstructProvenanceEntriesForUserAdminTx(t *testing.T) {
 		{
 			name: "delete existing users",
 			setup: func(db worldstate.DB) {
-				dbUpdates := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				dbUpdates := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key:   string(UserNamespace) + "user1",
@@ -499,9 +493,8 @@ func TestConstructProvenanceEntriesForUserAdminTx(t *testing.T) {
 		{
 			name: "read users and write existing users",
 			setup: func(db worldstate.DB) {
-				dbUpdates := []*worldstate.DBUpdates{
-					{
-						DBName: worldstate.UsersDBName,
+				dbUpdates := map[string]*worldstate.DBUpdates{
+					worldstate.UsersDBName: {
 						Writes: []*worldstate.KVWithMetadata{
 							{
 								Key:   string(UserNamespace) + "user2",
@@ -672,7 +665,6 @@ func TestConstructProvenanceEntriesForClusterAdmins(t *testing.T) {
 			name: "update and delete admins",
 			setup: func(db worldstate.DB) {
 				adminUpdates := &worldstate.DBUpdates{
-					DBName: worldstate.UsersDBName,
 					Writes: []*worldstate.KVWithMetadata{
 						{
 							Key:   string(UserNamespace) + "admin1",
@@ -691,7 +683,12 @@ func TestConstructProvenanceEntriesForClusterAdmins(t *testing.T) {
 					},
 				}
 
-				require.NoError(t, db.Commit([]*worldstate.DBUpdates{adminUpdates}, 1))
+				require.NoError(t, db.Commit(
+					map[string]*worldstate.DBUpdates{
+						worldstate.UsersDBName: adminUpdates,
+					},
+					1,
+				))
 			},
 			userID: "admin",
 			txID:   "tx1",
@@ -889,7 +886,6 @@ func TestConstructDBEntriesForNodes(t *testing.T) {
 			},
 			version: sampleVersion,
 			expectedUpdates: &worldstate.DBUpdates{
-				DBName: worldstate.ConfigDBName,
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:   string(NodeNamespace) + "node3",
@@ -930,7 +926,6 @@ func TestConstructDBEntriesForNodes(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, tt.expectedUpdates.DBName, updates.DBName)
 			require.Equal(t, tt.expectedUpdates.Deletes, updates.Deletes)
 
 			expectedWrites := make(map[string]*worldstate.KVWithMetadata)
@@ -1028,7 +1023,6 @@ func TestConstructProvenanceEntriesForNodes(t *testing.T) {
 			name: "update and delete nodes",
 			setup: func(db worldstate.DB) {
 				adminUpdates := &worldstate.DBUpdates{
-					DBName: worldstate.ConfigDBName,
 					Writes: []*worldstate.KVWithMetadata{
 						{
 							Key:   string(NodeNamespace) + "node1",
@@ -1047,7 +1041,12 @@ func TestConstructProvenanceEntriesForNodes(t *testing.T) {
 					},
 				}
 
-				require.NoError(t, db.Commit([]*worldstate.DBUpdates{adminUpdates}, 1))
+				require.NoError(t, db.Commit(
+					map[string]*worldstate.DBUpdates{
+						worldstate.ConfigDBName: adminUpdates,
+					},
+					1,
+				))
 			},
 			userID: "admin",
 			txID:   "tx1",

--- a/internal/identity/querier_test.go
+++ b/internal/identity/querier_test.go
@@ -105,9 +105,8 @@ func TestQuerier(t *testing.T) {
 		user, err := proto.Marshal(u)
 		require.NoError(t, err)
 
-		dbUpdates := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.UsersDBName,
+		dbUpdates := map[string]*worldstate.DBUpdates{
+			worldstate.UsersDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:      string(UserNamespace) + u.Id,

--- a/internal/worldstate/db.go
+++ b/internal/worldstate/db.go
@@ -50,7 +50,7 @@ type DB interface {
 	// GetConfig returns the cluster configuration
 	GetConfig() (*types.ClusterConfig, *types.Metadata, error)
 	// Commit commits the updates to each database
-	Commit(dbsUpdates []*DBUpdates, blockNumber uint64) error
+	Commit(dbsUpdates map[string]*DBUpdates, blockNumber uint64) error
 	// Height returns the state database block height. In other
 	// words, it returns the last committed block number
 	Height() (uint64, error)
@@ -70,7 +70,6 @@ type KVWithMetadata struct {
 // DBUpdates holds writes of KV pairs and deletes of
 // keys for each database
 type DBUpdates struct {
-	DBName  string
 	Writes  []*KVWithMetadata
 	Deletes []string
 }

--- a/internal/worldstate/leveldb/commit_and_query_test.go
+++ b/internal/worldstate/leveldb/commit_and_query_test.go
@@ -245,9 +245,8 @@ func TestCommitAndQuery(t *testing.T) {
 				},
 			},
 		}
-		dbsUpdates := []*worldstate.DBUpdates{
-			{
-				DBName: "db1",
+		dbsUpdates := map[string]*worldstate.DBUpdates{
+			"db1": {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:      "db1-key1",
@@ -261,8 +260,7 @@ func TestCommitAndQuery(t *testing.T) {
 					},
 				},
 			},
-			{
-				DBName: "db2",
+			"db2": {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:      "db2-key1",
@@ -409,9 +407,8 @@ func TestCommitAndQuery(t *testing.T) {
 				},
 			},
 		}
-		dbsUpdates := []*worldstate.DBUpdates{
-			{
-				DBName: "db1",
+		dbsUpdates := map[string]*worldstate.DBUpdates{
+			"db1": {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:      "db1-key1",
@@ -421,8 +418,7 @@ func TestCommitAndQuery(t *testing.T) {
 				},
 				Deletes: []string{"db1-key2"},
 			},
-			{
-				DBName: "db2",
+			"db2": {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:      "db2-key1",
@@ -485,7 +481,6 @@ func TestCommitWithDBManagement(t *testing.T) {
 			name:         "only create DBs",
 			preCreateDBs: nil,
 			updates: &worldstate.DBUpdates{
-				DBName: worldstate.DatabasesDBName,
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key: "db1",
@@ -501,7 +496,6 @@ func TestCommitWithDBManagement(t *testing.T) {
 			name:         "only delete DBs",
 			preCreateDBs: []string{"db1", "db2"},
 			updates: &worldstate.DBUpdates{
-				DBName:  worldstate.DatabasesDBName,
 				Deletes: []string{"db1", "db2"},
 			},
 			expectedDBsAfterCommit: nil,
@@ -510,7 +504,6 @@ func TestCommitWithDBManagement(t *testing.T) {
 			name:         "create and delete DBs",
 			preCreateDBs: []string{"db3", "db4"},
 			updates: &worldstate.DBUpdates{
-				DBName: worldstate.DatabasesDBName,
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key: "db1",
@@ -527,7 +520,6 @@ func TestCommitWithDBManagement(t *testing.T) {
 			name:         "create already existing DBs and delete non-existing DBs -- applicable during node failure and reply of block",
 			preCreateDBs: []string{"db1", "db3"},
 			updates: &worldstate.DBUpdates{
-				DBName: worldstate.DatabasesDBName,
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key: "db1",
@@ -558,8 +550,8 @@ func TestCommitWithDBManagement(t *testing.T) {
 			require.NoError(
 				t,
 				l.Commit(
-					[]*worldstate.DBUpdates{
-						tt.updates,
+					map[string]*worldstate.DBUpdates{
+						worldstate.DatabasesDBName: tt.updates,
 					},
 					1,
 				),
@@ -607,9 +599,8 @@ func TestGetConfig(t *testing.T) {
 			},
 		}
 
-		dbUpdates := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.ConfigDBName,
+		dbUpdates := map[string]*worldstate.DBUpdates{
+			worldstate.ConfigDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:      worldstate.ConfigKey,
@@ -637,9 +628,8 @@ func TestGetConfig(t *testing.T) {
 				TxNum:    5,
 			},
 		}
-		dbUpdates := []*worldstate.DBUpdates{
-			{
-				DBName: worldstate.ConfigDBName,
+		dbUpdates := map[string]*worldstate.DBUpdates{
+			worldstate.ConfigDBName: {
 				Writes: []*worldstate.KVWithMetadata{
 					{
 						Key:      worldstate.ConfigKey,
@@ -664,7 +654,7 @@ func TestHeight(t *testing.T) {
 	tests := []struct {
 		name           string
 		blockNumber    uint64
-		dbsUpdates     []*worldstate.DBUpdates
+		dbsUpdates     map[string]*worldstate.DBUpdates
 		expectedHeight uint64
 	}{
 		{
@@ -676,9 +666,8 @@ func TestHeight(t *testing.T) {
 		{
 			name:        "block 10 with non-empty updates",
 			blockNumber: 10,
-			dbsUpdates: []*worldstate.DBUpdates{
-				{
-					DBName:  worldstate.DefaultDBName,
+			dbsUpdates: map[string]*worldstate.DBUpdates{
+				worldstate.DefaultDBName: {
 					Deletes: []string{"key1"},
 				},
 			},


### PR DESCRIPTION
If we use one dbupdates for each tx in a block, we would do one sync write per tx.
As it degrades the performance, this PR makes one dbUpdates per database. As a result,
the number of sync writes would be equal to the number of dbs' data
modified in the block.

With this PR, the time taken to commit a block to worldstate reduced
from 150 msecs to 6 msecs

Signed-off-by: senthil <cendhu@gmail.com>