### PR TITLE
disallow multiple writes per key in a block

### DIFF
--- a/internal/bcdb/ledger_query_procesor_test.go
+++ b/internal/bcdb/ledger_query_procesor_test.go
@@ -365,7 +365,7 @@ func createDataUpdatesFromBlock(block *types.Block) map[string]*worldstate.DBUpd
 			TxNum:    uint64(txNum),
 		}
 
-		blockprocessor.AddDBEntriesForDataTxAndUpdateDirtyWrites(tx.GetPayload(), version, dataUpdate, nil)
+		blockprocessor.AddDBEntriesForDataTx(tx.GetPayload(), version, dataUpdate)
 	}
 
 	return dataUpdate

--- a/internal/bcdb/provenance_query_processor_test.go
+++ b/internal/bcdb/provenance_query_processor_test.go
@@ -143,39 +143,6 @@ func setupProvenanceStore(t *testing.T, s *provenance.Store) {
 				},
 			},
 		},
-		{
-			IsValid: true,
-			DBName:  "db1",
-			UserID:  "user2",
-			TxID:    "tx4",
-			Reads: []*provenance.KeyWithVersion{
-				{
-					Key: "key2",
-					Version: &types.Version{
-						BlockNum: 1,
-						TxNum:    1,
-					},
-				},
-			},
-			Writes: []*types.KVWithMetadata{
-				{
-					Key:   "key1",
-					Value: []byte("value3"),
-					Metadata: &types.Metadata{
-						Version: &types.Version{
-							BlockNum: 2,
-							TxNum:    1,
-						},
-					},
-				},
-			},
-			OldVersionOfWrites: map[string]*types.Version{
-				"key1": {
-					BlockNum: 2,
-					TxNum:    0,
-				},
-			},
-		},
 	}
 
 	block3TxsData := []*provenance.TxDataForProvenance{
@@ -189,7 +156,7 @@ func setupProvenanceStore(t *testing.T, s *provenance.Store) {
 					Key: "key1",
 					Version: &types.Version{
 						BlockNum: 2,
-						TxNum:    1,
+						TxNum:    0,
 					},
 				},
 				{
@@ -231,7 +198,7 @@ func setupProvenanceStore(t *testing.T, s *provenance.Store) {
 			OldVersionOfWrites: map[string]*types.Version{
 				"key1": {
 					BlockNum: 2,
-					TxNum:    1,
+					TxNum:    0,
 				},
 				"key2": {
 					BlockNum: 1,
@@ -347,15 +314,6 @@ func TestGetValues(t *testing.T) {
 						},
 					},
 					{
-						Value: []byte("value3"),
-						Metadata: &types.Metadata{
-							Version: &types.Version{
-								BlockNum: 2,
-								TxNum:    1,
-							},
-						},
-					},
-					{
 						Value: []byte("value4"),
 						Metadata: &types.Metadata{
 							Version: &types.Version{
@@ -467,12 +425,12 @@ func TestGetPreviousValues(t *testing.T) {
 		expectedPayload *types.GetHistoricalDataResponse
 	}{
 		{
-			name:   "fetch the previous value of key1 at version{Blk 2, txNum 1}",
+			name:   "fetch the previous value of key1 at version{Blk 3, txNum 0}",
 			dbName: "db1",
 			key:    "key1",
 			version: &types.Version{
-				BlockNum: 2,
-				TxNum:    1,
+				BlockNum: 3,
+				TxNum:    0,
 			},
 			expectedPayload: &types.GetHistoricalDataResponse{
 				Values: []*types.ValueWithMetadata{
@@ -532,12 +490,12 @@ func TestGetNextValues(t *testing.T) {
 		expectedPayload *types.GetHistoricalDataResponse
 	}{
 		{
-			name:   "fetch next value of key1 at version {Blk 2, txNum 1}",
+			name:   "fetch next value of key1 at version {Blk 2, txNum 0}",
 			dbName: "db1",
 			key:    "key1",
 			version: &types.Version{
 				BlockNum: 2,
-				TxNum:    1,
+				TxNum:    0,
 			},
 			expectedPayload: &types.GetHistoricalDataResponse{
 				Values: []*types.ValueWithMetadata{
@@ -603,17 +561,17 @@ func TestGetValueAt(t *testing.T) {
 			dbName: "db1",
 			key:    "key1",
 			version: &types.Version{
-				BlockNum: 2,
-				TxNum:    1,
+				BlockNum: 3,
+				TxNum:    0,
 			},
 			expectedPayload: &types.GetHistoricalDataResponse{
 				Values: []*types.ValueWithMetadata{
 					{
-						Value: []byte("value3"),
+						Value: []byte("value4"),
 						Metadata: &types.Metadata{
 							Version: &types.Version{
-								BlockNum: 2,
-								TxNum:    1,
+								BlockNum: 3,
+								TxNum:    0,
 							},
 						},
 					},
@@ -667,11 +625,11 @@ func TestGetMostRecentValueAtOrBelow(t *testing.T) {
 			expectedPayload: &types.GetHistoricalDataResponse{
 				Values: []*types.ValueWithMetadata{
 					{
-						Value: []byte("value3"),
+						Value: []byte("value2"),
 						Metadata: &types.Metadata{
 							Version: &types.Version{
 								BlockNum: 2,
-								TxNum:    1,
+								TxNum:    0,
 							},
 						},
 					},
@@ -762,7 +720,7 @@ func TestGetWriters(t *testing.T) {
 			expectedPayload: &types.GetDataWritersResponse{
 				WrittenBy: map[string]uint32{
 					"user1": 2,
-					"user2": 3,
+					"user2": 2,
 				},
 			},
 		},
@@ -976,7 +934,7 @@ func TestGetTxSubmittedByUser(t *testing.T) {
 			name: "fetch tx submitted by user",
 			user: "user2",
 			expectedPayload: &types.GetTxIDsSubmittedByResponse{
-				TxIDs: []string{"tx4", "tx5", "tx50", "tx6"},
+				TxIDs: []string{"tx5", "tx50", "tx6"},
 			},
 		},
 		{

--- a/internal/blockprocessor/data_tx_validator_test.go
+++ b/internal/blockprocessor/data_tx_validator_test.go
@@ -2015,17 +2015,22 @@ func TestMVCCOnDataTx(t *testing.T) {
 	tests := []struct {
 		name           string
 		setup          func(db worldstate.DB)
+		txOps          *types.DBOperation
 		dataReads      []*types.DataRead
+		dataWrites     []*types.DataWrite
+		dataDeletes    []*types.DataDelete
 		pendingOps     *pendingOperations
 		expectedResult *types.ValidationInfo
 	}{
 		{
 			name:  "invalid: conflict writes within the block",
 			setup: func(db worldstate.DB) {},
-			dataReads: []*types.DataRead{
-				{
-					Key:     "key1",
-					Version: version1,
+			txOps: &types.DBOperation{
+				DataReads: []*types.DataRead{
+					{
+						Key:     "key1",
+						Version: version1,
+					},
 				},
 			},
 			pendingOps: &pendingOperations{
@@ -2042,10 +2047,12 @@ func TestMVCCOnDataTx(t *testing.T) {
 		{
 			name:  "invalid: conflict deletes within the block",
 			setup: func(db worldstate.DB) {},
-			dataReads: []*types.DataRead{
-				{
-					Key:     "key1",
-					Version: version1,
+			txOps: &types.DBOperation{
+				DataReads: []*types.DataRead{
+					{
+						Key:     "key1",
+						Version: version1,
+					},
 				},
 			},
 			pendingOps: &pendingOperations{
@@ -2060,12 +2067,100 @@ func TestMVCCOnDataTx(t *testing.T) {
 			},
 		},
 		{
+			name:  "invalid: more than one modification per key - conflict between write and delete",
+			setup: func(db worldstate.DB) {},
+			txOps: &types.DBOperation{
+				DataWrites: []*types.DataWrite{
+					{
+						Key:   "key1",
+						Value: []byte("value1"),
+					},
+				},
+			},
+			pendingOps: &pendingOperations{
+				pendingWrites: map[string]bool{},
+				pendingDeletes: map[string]bool{
+					constructCompositeKey(worldstate.DefaultDBName, "key1"): true,
+				},
+			},
+			expectedResult: &types.ValidationInfo{
+				Flag:            types.Flag_INVALID_MVCC_CONFLICT_WITHIN_BLOCK,
+				ReasonIfInvalid: "mvcc conflict has occurred within the block for the key [key1] in database [" + worldstate.DefaultDBName + "]. Within a block, a key can be modified only once",
+			},
+		},
+		{
+			name:  "invalid: more than one modification per key - conflict between write and write",
+			setup: func(db worldstate.DB) {},
+			txOps: &types.DBOperation{
+				DataWrites: []*types.DataWrite{
+					{
+						Key:   "key1",
+						Value: []byte("value1"),
+					},
+				},
+			},
+			pendingOps: &pendingOperations{
+				pendingWrites: map[string]bool{
+					constructCompositeKey(worldstate.DefaultDBName, "key1"): true,
+				},
+				pendingDeletes: map[string]bool{},
+			},
+			expectedResult: &types.ValidationInfo{
+				Flag:            types.Flag_INVALID_MVCC_CONFLICT_WITHIN_BLOCK,
+				ReasonIfInvalid: "mvcc conflict has occurred within the block for the key [key1] in database [" + worldstate.DefaultDBName + "]. Within a block, a key can be modified only once",
+			},
+		},
+		{
+			name:  "invalid: more than one modification per key - conflict between delete and write",
+			setup: func(db worldstate.DB) {},
+			txOps: &types.DBOperation{
+				DataDeletes: []*types.DataDelete{
+					{
+						Key: "key1",
+					},
+				},
+			},
+			pendingOps: &pendingOperations{
+				pendingWrites: map[string]bool{
+					constructCompositeKey(worldstate.DefaultDBName, "key1"): true,
+				},
+				pendingDeletes: map[string]bool{},
+			},
+			expectedResult: &types.ValidationInfo{
+				Flag:            types.Flag_INVALID_MVCC_CONFLICT_WITHIN_BLOCK,
+				ReasonIfInvalid: "mvcc conflict has occurred within the block for the key [key1] in database [" + worldstate.DefaultDBName + "]. Within a block, a key can be modified only once",
+			},
+		},
+		{
+			name:  "invalid: more than one modification per key - conflict between delete and delete",
+			setup: func(db worldstate.DB) {},
+			txOps: &types.DBOperation{
+				DataDeletes: []*types.DataDelete{
+					{
+						Key: "key1",
+					},
+				},
+			},
+			pendingOps: &pendingOperations{
+				pendingWrites: map[string]bool{},
+				pendingDeletes: map[string]bool{
+					constructCompositeKey(worldstate.DefaultDBName, "key1"): true,
+				},
+			},
+			expectedResult: &types.ValidationInfo{
+				Flag:            types.Flag_INVALID_MVCC_CONFLICT_WITHIN_BLOCK,
+				ReasonIfInvalid: "mvcc conflict has occurred within the block for the key [key1] in database [" + worldstate.DefaultDBName + "]. Within a block, a key can be modified only once",
+			},
+		},
+		{
 			name:  "invalid: committed version does not exist",
 			setup: func(db worldstate.DB) {},
-			dataReads: []*types.DataRead{
-				{
-					Key:     "key1",
-					Version: version1,
+			txOps: &types.DBOperation{
+				DataReads: []*types.DataRead{
+					{
+						Key:     "key1",
+						Version: version1,
+					},
 				},
 			},
 			pendingOps: newPendingOperations(),
@@ -2098,14 +2193,16 @@ func TestMVCCOnDataTx(t *testing.T) {
 
 				require.NoError(t, db.Commit(data, 1))
 			},
-			dataReads: []*types.DataRead{
-				{
-					Key:     "key1",
-					Version: version2,
-				},
-				{
-					Key:     "key2",
-					Version: version1,
+			txOps: &types.DBOperation{
+				DataReads: []*types.DataRead{
+					{
+						Key:     "key1",
+						Version: version2,
+					},
+					{
+						Key:     "key2",
+						Version: version1,
+					},
 				},
 			},
 			pendingOps: newPendingOperations(),
@@ -2138,18 +2235,20 @@ func TestMVCCOnDataTx(t *testing.T) {
 
 				require.NoError(t, db.Commit(data, 1))
 			},
-			dataReads: []*types.DataRead{
-				{
-					Key:     "key1",
-					Version: version2,
-				},
-				{
-					Key:     "key2",
-					Version: version3,
-				},
-				{
-					Key:     "key3",
-					Version: nil,
+			txOps: &types.DBOperation{
+				DataReads: []*types.DataRead{
+					{
+						Key:     "key1",
+						Version: version2,
+					},
+					{
+						Key:     "key2",
+						Version: version3,
+					},
+					{
+						Key:     "key3",
+						Version: nil,
+					},
 				},
 			},
 			pendingOps: newPendingOperations(),
@@ -2169,7 +2268,7 @@ func TestMVCCOnDataTx(t *testing.T) {
 
 			tt.setup(env.db)
 
-			result, err := env.validator.dataTxValidator.mvccValidation(worldstate.DefaultDBName, tt.dataReads, tt.pendingOps)
+			result, err := env.validator.dataTxValidator.mvccValidation(worldstate.DefaultDBName, tt.txOps, tt.pendingOps)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedResult, result)
 		})

--- a/internal/blockprocessor/validator_test.go
+++ b/internal/blockprocessor/validator_test.go
@@ -577,6 +577,33 @@ func TestValidateDataBlock(t *testing.T) {
 									},
 								},
 							}),
+							testutils.SignedDataTxEnvelope(t, []crypto.Signer{userSigner}, &types.DataTx{
+								MustSignUserIds: []string{"operatingUser"},
+								DbOperations: []*types.DBOperation{
+									{
+										DbName: worldstate.DefaultDBName,
+										DataWrites: []*types.DataWrite{
+											{
+												Key:   "key1",
+												Value: []byte("new-val"),
+											},
+										},
+									},
+								},
+							}),
+							testutils.SignedDataTxEnvelope(t, []crypto.Signer{userSigner}, &types.DataTx{
+								MustSignUserIds: []string{"operatingUser"},
+								DbOperations: []*types.DBOperation{
+									{
+										DbName: "db1",
+										DataDeletes: []*types.DataDelete{
+											{
+												Key: "key1",
+											},
+										},
+									},
+								},
+							}),
 						},
 					},
 				},
@@ -596,6 +623,14 @@ func TestValidateDataBlock(t *testing.T) {
 				{
 					Flag:            types.Flag_INVALID_DATABASE_DOES_NOT_EXIST,
 					ReasonIfInvalid: "the database [db2] does not exist in the cluster",
+				},
+				{
+					Flag:            types.Flag_INVALID_MVCC_CONFLICT_WITHIN_BLOCK,
+					ReasonIfInvalid: "mvcc conflict has occurred within the block for the key [key1] in database [" + worldstate.DefaultDBName + "]. Within a block, a key can be modified only once",
+				},
+				{
+					Flag:            types.Flag_INVALID_MVCC_CONFLICT_WITHIN_BLOCK,
+					ReasonIfInvalid: "mvcc conflict has occurred within the block for the key [key1] in database [db1]. Within a block, a key can be modified only once",
 				},
 			},
 		},

--- a/internal/provenance/commit_and_query_test.go
+++ b/internal/provenance/commit_and_query_test.go
@@ -144,39 +144,6 @@ func setup(t *testing.T, s *Store) {
 				},
 			},
 		},
-		{
-			IsValid: true,
-			DBName:  "db1",
-			UserID:  "user2",
-			TxID:    "tx4",
-			Reads: []*KeyWithVersion{
-				{
-					Key: "key2",
-					Version: &types.Version{
-						BlockNum: 1,
-						TxNum:    1,
-					},
-				},
-			},
-			Writes: []*types.KVWithMetadata{
-				{
-					Key:   "key1",
-					Value: []byte("value3"),
-					Metadata: &types.Metadata{
-						Version: &types.Version{
-							BlockNum: 2,
-							TxNum:    1,
-						},
-					},
-				},
-			},
-			OldVersionOfWrites: map[string]*types.Version{
-				"key1": {
-					BlockNum: 2,
-					TxNum:    0,
-				},
-			},
-		},
 	}
 
 	block3TxsData := []*TxDataForProvenance{
@@ -190,7 +157,7 @@ func setup(t *testing.T, s *Store) {
 					Key: "key1",
 					Version: &types.Version{
 						BlockNum: 2,
-						TxNum:    1,
+						TxNum:    0,
 					},
 				},
 				{
@@ -232,7 +199,7 @@ func setup(t *testing.T, s *Store) {
 			OldVersionOfWrites: map[string]*types.Version{
 				"key1": {
 					BlockNum: 2,
-					TxNum:    1,
+					TxNum:    0,
 				},
 				"key2": {
 					BlockNum: 1,
@@ -426,15 +393,6 @@ func TestGetValues(t *testing.T) {
 					},
 				},
 				{
-					Value: []byte("value3"),
-					Metadata: &types.Metadata{
-						Version: &types.Version{
-							BlockNum: 2,
-							TxNum:    1,
-						},
-					},
-				},
-				{
 					Value: []byte("value4"),
 					Metadata: &types.Metadata{
 						Version: &types.Version{
@@ -529,7 +487,7 @@ func TestGetTxSubmittedByUser(t *testing.T) {
 		{
 			name:          "fetch ids of tx submitted by user2",
 			userID:        "user2",
-			expectedTxIDs: []string{"tx4", "tx5", "tx50", "tx6"},
+			expectedTxIDs: []string{"tx5", "tx50", "tx6"},
 		},
 		{
 			name:          "fetch non-existing transaction",
@@ -541,7 +499,6 @@ func TestGetTxSubmittedByUser(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-
 			txIDs, err := env.s.GetTxIDsSubmittedByUser(tt.userID)
 			require.NoError(t, err)
 			require.ElementsMatch(t, tt.expectedTxIDs, txIDs)
@@ -576,7 +533,7 @@ func TestGetReaders(t *testing.T) {
 			dbName: "db1",
 			key:    "key2",
 			expectedReaders: map[string]uint32{
-				"user2": 2,
+				"user2": 1,
 			},
 		},
 		{
@@ -616,7 +573,7 @@ func TestGetWriters(t *testing.T) {
 			key:    "key1",
 			expectedWriters: map[string]uint32{
 				"user1": 2,
-				"user2": 3,
+				"user2": 2,
 			},
 		},
 		{
@@ -696,27 +653,11 @@ func TestGetValuesReadByUser(t *testing.T) {
 				},
 				{
 					Key:   "key1",
-					Value: []byte("value3"),
+					Value: []byte("value2"),
 					Metadata: &types.Metadata{
 						Version: &types.Version{
 							BlockNum: 2,
-							TxNum:    1,
-						},
-					},
-				},
-				{
-					Key:   "key2",
-					Value: []byte("value1"),
-					Metadata: &types.Metadata{
-						AccessControl: &types.AccessControl{
-							ReadWriteUsers: map[string]bool{
-								"user1": true,
-								"user2": true,
-							},
-						},
-						Version: &types.Version{
-							BlockNum: 1,
-							TxNum:    1,
+							TxNum:    0,
 						},
 					},
 				},
@@ -797,16 +738,6 @@ func TestGetValuesWrittenByUser(t *testing.T) {
 			name:   "fetch all values written by user2",
 			userID: "user2",
 			expectedWrites: []*types.KVWithMetadata{
-				{
-					Key:   "key1",
-					Value: []byte("value3"),
-					Metadata: &types.Metadata{
-						Version: &types.Version{
-							BlockNum: 2,
-							TxNum:    1,
-						},
-					},
-				},
 				{
 					Key:   "key1",
 					Value: []byte("value4"),
@@ -897,15 +828,6 @@ func TestGetNextValues(t *testing.T) {
 					},
 				},
 				{
-					Value: []byte("value3"),
-					Metadata: &types.Metadata{
-						Version: &types.Version{
-							BlockNum: 2,
-							TxNum:    1,
-						},
-					},
-				},
-				{
 					Value: []byte("value4"),
 					Metadata: &types.Metadata{
 						Version: &types.Version{
@@ -935,15 +857,6 @@ func TestGetNextValues(t *testing.T) {
 			},
 			limit: -1,
 			expectedValues: []*types.ValueWithMetadata{
-				{
-					Value: []byte("value3"),
-					Metadata: &types.Metadata{
-						Version: &types.Version{
-							BlockNum: 2,
-							TxNum:    1,
-						},
-					},
-				},
 				{
 					Value: []byte("value4"),
 					Metadata: &types.Metadata{
@@ -1016,11 +929,11 @@ func TestGetNextValues(t *testing.T) {
 					},
 				},
 				{
-					Value: []byte("value3"),
+					Value: []byte("value4"),
 					Metadata: &types.Metadata{
 						Version: &types.Version{
-							BlockNum: 2,
-							TxNum:    1,
+							BlockNum: 3,
+							TxNum:    0,
 						},
 					},
 				},
@@ -1092,24 +1005,15 @@ func TestGetPreviousValues(t *testing.T) {
 						},
 					},
 				},
-				{
-					Value: []byte("value3"),
-					Metadata: &types.Metadata{
-						Version: &types.Version{
-							BlockNum: 2,
-							TxNum:    1,
-						},
-					},
-				},
 			},
 		},
 		{
-			name:   "all previous values of key1, value3",
+			name:   "all previous values of key1, value2",
 			dbName: "db1",
 			key:    "key1",
 			version: &types.Version{
 				BlockNum: 2,
-				TxNum:    1,
+				TxNum:    0,
 			},
 			limit: -1,
 			expectedValues: []*types.ValueWithMetadata{
@@ -1118,15 +1022,6 @@ func TestGetPreviousValues(t *testing.T) {
 					Metadata: &types.Metadata{
 						Version: &types.Version{
 							BlockNum: 1,
-							TxNum:    0,
-						},
-					},
-				},
-				{
-					Value: []byte("value2"),
-					Metadata: &types.Metadata{
-						Version: &types.Version{
-							BlockNum: 2,
 							TxNum:    0,
 						},
 					},
@@ -1164,11 +1059,11 @@ func TestGetPreviousValues(t *testing.T) {
 					},
 				},
 				{
-					Value: []byte("value3"),
+					Value: []byte("value1"),
 					Metadata: &types.Metadata{
 						Version: &types.Version{
-							BlockNum: 2,
-							TxNum:    1,
+							BlockNum: 1,
+							TxNum:    0,
 						},
 					},
 				},
@@ -1185,11 +1080,11 @@ func TestGetPreviousValues(t *testing.T) {
 			limit: 2,
 			expectedValues: []*types.ValueWithMetadata{
 				{
-					Value: []byte("value3"),
+					Value: []byte("value2"),
 					Metadata: &types.Metadata{
 						Version: &types.Version{
 							BlockNum: 2,
-							TxNum:    1,
+							TxNum:    0,
 						},
 					},
 				},
@@ -1427,15 +1322,15 @@ func TestGetMostRecentValueAtOrBelow(t *testing.T) {
 			dbName: "db1",
 			key:    "key1",
 			version: &types.Version{
-				BlockNum: 2,
-				TxNum:    1,
+				BlockNum: 3,
+				TxNum:    0,
 			},
 			expectedValue: &types.ValueWithMetadata{
-				Value: []byte("value3"),
+				Value: []byte("value4"),
 				Metadata: &types.Metadata{
 					Version: &types.Version{
-						BlockNum: 2,
-						TxNum:    1,
+						BlockNum: 3,
+						TxNum:    0,
 					},
 				},
 			},
@@ -1485,11 +1380,11 @@ func TestGetMostRecentValueAtOrBelow(t *testing.T) {
 				TxNum:    10,
 			},
 			expectedValue: &types.ValueWithMetadata{
-				Value: []byte("value3"),
+				Value: []byte("value2"),
 				Metadata: &types.Metadata{
 					Version: &types.Version{
 						BlockNum: 2,
-						TxNum:    1,
+						TxNum:    0,
 					},
 				},
 			},


### PR DESCRIPTION
The state trie works at a block boundary. As a result,
the state trie only considers the final updates for a
block even if there are multiple blind writes. However,
provenance store keeps tracks of all blind writes and
delete to a key within a block. This create problem
in generating proof of existence for intermediate values.

To solve the above problem and simplify things, we
restrict only one write per key in a block.

Further, this helps in parallelizing certain operations
in the provenance store.

Signed-off-by: senthil <cendhu@gmail.com>