### PR TITLE
Missing zap duration encoder

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -46,6 +46,8 @@ func New(c *Config) (*SugarLogger, error) {
 
 			CallerKey:    "caller",
 			EncodeCaller: zapcore.ShortCallerEncoder,
+
+			EncodeDuration: zapcore.StringDurationEncoder,
 		},
 	}
 


### PR DESCRIPTION
Bug reported in https://github.com/ibm-blockchain/bcdb-server/issues/116

A missing zap duration encoder in the logger config results is a
`panic: runtime error: invalid memory address or nil pointer dereference`
because the function pointer for the encoder is missing.

Signed-off-by: Yoav Tock <tock@il.ibm.com>