### PR TITLE
Parallel verification of signatures in a block

### DIFF
--- a/internal/bcdb/ledger_query_procesor_test.go
+++ b/internal/bcdb/ledger_query_procesor_test.go
@@ -370,7 +370,6 @@ func createDataUpdatesFromBlock(block *types.Block) map[string]*worldstate.DBUpd
 }
 
 func TestGetBlock(t *testing.T) {
-	t.Parallel()
 	env := newLedgerProcessorTestEnv(t)
 	defer env.cleanup(t)
 	setup(t, env, 20)
@@ -449,7 +448,6 @@ func TestGetBlock(t *testing.T) {
 }
 
 func TestGetPath(t *testing.T) {
-	t.Parallel()
 	env := newLedgerProcessorTestEnv(t)
 	defer env.cleanup(t)
 	setup(t, env, 100)
@@ -544,7 +542,6 @@ func TestGetPath(t *testing.T) {
 }
 
 func TestGetTxProof(t *testing.T) {
-	t.Parallel()
 	env := newLedgerProcessorTestEnv(t)
 	defer env.cleanup(t)
 	setup(t, env, 100)
@@ -650,7 +647,6 @@ func TestGetTxProof(t *testing.T) {
 }
 
 func TestGetDataProof(t *testing.T) {
-	t.Parallel()
 	env := newLedgerProcessorTestEnv(t)
 	defer env.cleanup(t)
 	setup(t, env, 100)
@@ -758,7 +754,6 @@ func TestGetDataProof(t *testing.T) {
 }
 
 func TestGetTxReceipt(t *testing.T) {
-	t.Parallel()
 	env := newLedgerProcessorTestEnv(t)
 	defer env.cleanup(t)
 	setup(t, env, 20)

--- a/internal/bcdb/provenance_query_processor_test.go
+++ b/internal/bcdb/provenance_query_processor_test.go
@@ -24,7 +24,7 @@ func newProvenanceQueryProcessorTestEnv(t *testing.T) *provenanceQueryProcessorT
 	require.NoError(t, err)
 
 	c := &logger.Config{
-		Level:         "debug",
+		Level:         "info",
 		OutputPath:    []string{"stdout"},
 		ErrOutputPath: []string{"stderr"},
 		Encoding:      "console",
@@ -311,7 +311,6 @@ func setupProvenanceStore(t *testing.T, s *provenance.Store) {
 }
 
 func TestGetValues(t *testing.T) {
-	t.Parallel()
 	env := newProvenanceQueryProcessorTestEnv(t)
 	defer env.cleanup(t)
 
@@ -397,7 +396,6 @@ func TestGetValues(t *testing.T) {
 }
 
 func TestGetDeletedValues(t *testing.T) {
-	t.Parallel()
 	env := newProvenanceQueryProcessorTestEnv(t)
 	defer env.cleanup(t)
 
@@ -456,7 +454,6 @@ func TestGetDeletedValues(t *testing.T) {
 }
 
 func TestGetPreviousValues(t *testing.T) {
-	t.Parallel()
 	env := newProvenanceQueryProcessorTestEnv(t)
 	defer env.cleanup(t)
 
@@ -522,7 +519,6 @@ func TestGetPreviousValues(t *testing.T) {
 }
 
 func TestGetNextValues(t *testing.T) {
-	t.Parallel()
 	env := newProvenanceQueryProcessorTestEnv(t)
 	defer env.cleanup(t)
 
@@ -590,7 +586,6 @@ func TestGetNextValues(t *testing.T) {
 }
 
 func TestGetValueAt(t *testing.T) {
-	t.Parallel()
 	env := newProvenanceQueryProcessorTestEnv(t)
 	defer env.cleanup(t)
 
@@ -649,7 +644,6 @@ func TestGetValueAt(t *testing.T) {
 }
 
 func TestGetMostRecentValueAtOrBelow(t *testing.T) {
-	t.Parallel()
 	env := newProvenanceQueryProcessorTestEnv(t)
 	defer env.cleanup(t)
 
@@ -708,7 +702,6 @@ func TestGetMostRecentValueAtOrBelow(t *testing.T) {
 }
 
 func TestGetReaders(t *testing.T) {
-	t.Parallel()
 	env := newProvenanceQueryProcessorTestEnv(t)
 	defer env.cleanup(t)
 
@@ -751,7 +744,6 @@ func TestGetReaders(t *testing.T) {
 }
 
 func TestGetWriters(t *testing.T) {
-	t.Parallel()
 	env := newProvenanceQueryProcessorTestEnv(t)
 	defer env.cleanup(t)
 
@@ -793,7 +785,6 @@ func TestGetWriters(t *testing.T) {
 }
 
 func TestGetValuesReadByUser(t *testing.T) {
-	t.Parallel()
 	env := newProvenanceQueryProcessorTestEnv(t)
 	defer env.cleanup(t)
 
@@ -841,7 +832,6 @@ func TestGetValuesReadByUser(t *testing.T) {
 }
 
 func TestGetValuesWrittenByUser(t *testing.T) {
-	t.Parallel()
 	env := newProvenanceQueryProcessorTestEnv(t)
 	defer env.cleanup(t)
 
@@ -915,7 +905,6 @@ func TestGetValuesWrittenByUser(t *testing.T) {
 }
 
 func TestGetValuesDeletedByUser(t *testing.T) {
-	t.Parallel()
 	env := newProvenanceQueryProcessorTestEnv(t)
 	defer env.cleanup(t)
 
@@ -973,7 +962,6 @@ func TestGetValuesDeletedByUser(t *testing.T) {
 }
 
 func TestGetTxSubmittedByUser(t *testing.T) {
-	t.Parallel()
 	env := newProvenanceQueryProcessorTestEnv(t)
 	defer env.cleanup(t)
 

--- a/internal/bcdb/transaction_processor_test.go
+++ b/internal/bcdb/transaction_processor_test.go
@@ -209,10 +209,7 @@ func setupTxProcessor(t *testing.T, env *txProcessorTestEnv, dbName string) {
 }
 
 func TestTransactionProcessor(t *testing.T) {
-	t.Parallel()
-
 	t.Run("commit a data transaction asynchronously", func(t *testing.T) {
-		t.Parallel()
 		cryptoDir, conf := testConfiguration(t)
 		require.NotEqual(t, "", cryptoDir)
 		defer os.RemoveAll(conf.LocalConfig.Server.Database.LedgerDirectory)
@@ -325,7 +322,6 @@ func TestTransactionProcessor(t *testing.T) {
 	})
 
 	t.Run("commit a data transaction synchronously", func(t *testing.T) {
-		t.Parallel()
 		cryptoDir, conf := testConfiguration(t)
 		require.NotEqual(t, "", cryptoDir)
 		defer os.RemoveAll(conf.LocalConfig.Server.Database.LedgerDirectory)
@@ -433,7 +429,6 @@ func TestTransactionProcessor(t *testing.T) {
 	})
 
 	t.Run("duplicate txID with the already committed transaction", func(t *testing.T) {
-		t.Parallel()
 		cryptoDir, conf := testConfiguration(t)
 		require.NotEqual(t, "", cryptoDir)
 		defer os.RemoveAll(conf.LocalConfig.Server.Database.LedgerDirectory)
@@ -470,7 +465,6 @@ func TestTransactionProcessor(t *testing.T) {
 	})
 
 	t.Run("duplicate txID with either pending or already committed transaction", func(t *testing.T) {
-		t.Parallel()
 		cryptoDir, conf := testConfiguration(t)
 		require.NotEqual(t, "", cryptoDir)
 		defer os.RemoveAll(conf.LocalConfig.Server.Database.LedgerDirectory)
@@ -511,7 +505,6 @@ func TestTransactionProcessor(t *testing.T) {
 	})
 
 	t.Run("duplicate txID with either pending or already committed transaction", func(t *testing.T) {
-		t.Parallel()
 		cryptoDir, conf := testConfiguration(t)
 		require.NotEqual(t, "", cryptoDir)
 		defer os.RemoveAll(conf.LocalConfig.Server.Database.LedgerDirectory)
@@ -629,7 +622,7 @@ func testConfiguration(t *testing.T) (string, *config.Configurations) {
 					ReorderedTransactionBatch: 100,
 					Block:                     100,
 				},
-				LogLevel: "debug",
+				LogLevel: "info",
 			},
 			BlockCreation: config.BlockCreationConf{
 				MaxBlockSize:                2,

--- a/internal/bcdb/worldstate_query_processor_test.go
+++ b/internal/bcdb/worldstate_query_processor_test.go
@@ -29,7 +29,7 @@ func newWorldstateQueryProcessorTestEnv(t *testing.T) *worldstateQueryProcessorT
 	require.NoError(t, err)
 
 	c := &logger.Config{
-		Level:         "debug",
+		Level:         "info",
 		OutputPath:    []string{"stdout"},
 		ErrOutputPath: []string{"stderr"},
 		Encoding:      "console",
@@ -77,10 +77,9 @@ func newWorldstateQueryProcessorTestEnv(t *testing.T) *worldstateQueryProcessorT
 }
 
 func TestGetDBStatus(t *testing.T) {
-	t.Parallel()
 
 	t.Run("getDBStatus-Returns-Status", func(t *testing.T) {
-		t.Parallel()
+
 		env := newWorldstateQueryProcessorTestEnv(t)
 		defer env.cleanup(t)
 
@@ -119,7 +118,6 @@ func TestGetDBStatus(t *testing.T) {
 }
 
 func TestGetData(t *testing.T) {
-	t.Parallel()
 
 	setup := func(db worldstate.DB, userID, dbName string) {
 		user := &types.User{
@@ -165,7 +163,7 @@ func TestGetData(t *testing.T) {
 	}
 
 	t.Run("getData returns data", func(t *testing.T) {
-		t.Parallel()
+
 		env := newWorldstateQueryProcessorTestEnv(t)
 		defer env.cleanup(t)
 
@@ -241,7 +239,7 @@ func TestGetData(t *testing.T) {
 	})
 
 	t.Run("getData returns permission error due to ACL", func(t *testing.T) {
-		t.Parallel()
+
 		env := newWorldstateQueryProcessorTestEnv(t)
 		defer env.cleanup(t)
 
@@ -282,7 +280,7 @@ func TestGetData(t *testing.T) {
 	})
 
 	t.Run("getData returns permission error due to directly accessing system database", func(t *testing.T) {
-		t.Parallel()
+
 		env := newWorldstateQueryProcessorTestEnv(t)
 		defer env.cleanup(t)
 
@@ -327,7 +325,6 @@ func TestGetData(t *testing.T) {
 }
 
 func TestGetUser(t *testing.T) {
-	t.Parallel()
 
 	t.Run("query existing user", func(t *testing.T) {
 		querierUser := &types.User{
@@ -511,7 +508,6 @@ func TestGetUser(t *testing.T) {
 	})
 
 	t.Run("error expected", func(t *testing.T) {
-		t.Parallel()
 
 		querierUser := &types.User{
 			Id: "querierUser",
@@ -580,7 +576,6 @@ func TestGetUser(t *testing.T) {
 		for _, tt := range tests {
 			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
-				t.Parallel()
 
 				env := newWorldstateQueryProcessorTestEnv(t)
 				defer env.cleanup(t)
@@ -596,7 +591,6 @@ func TestGetUser(t *testing.T) {
 }
 
 func TestGetConfig(t *testing.T) {
-	t.Parallel()
 
 	t.Run("getConfig returns config", func(t *testing.T) {
 		env := newWorldstateQueryProcessorTestEnv(t)

--- a/internal/blockprocessor/data_tx_validator_test.go
+++ b/internal/blockprocessor/data_tx_validator_test.go
@@ -195,7 +195,7 @@ func TestValidateDataTx(t *testing.T) {
 			pendingOps: newPendingOperations(),
 			expectedResult: &types.ValidationInfo{
 				Flag:            types.Flag_INVALID_UNAUTHORISED,
-				ReasonIfInvalid: "signature of the must sign user [" + alice + "] is not valid (maybe the certifcate got changed)",
+				ReasonIfInvalid: "signature of the must sign user [" + alice + "] is not valid (maybe the certificate got changed)",
 			},
 		},
 		{
@@ -1009,7 +1009,14 @@ func TestValidateDataTx(t *testing.T) {
 
 			tt.setup(env.db)
 
-			result, err := env.validator.dataTxValidator.validate(tt.txEnv, tt.pendingOps)
+			usersWithValidSignTx, valInfo, err := env.validator.dataTxValidator.validateSignatures(tt.txEnv)
+			require.NoError(t, err)
+			if valInfo.Flag != types.Flag_VALID {
+				require.Equal(t, tt.expectedResult, valInfo)
+				return
+			}
+
+			result, err := env.validator.dataTxValidator.validate(tt.txEnv, usersWithValidSignTx, tt.pendingOps)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedResult, result)
 		})


### PR DESCRIPTION
Validate the signatures on transactions in a block in parallel rather then serially, for performance.

First validate the signatures on each transaction in parallel, remembering the
set of users with valid signatures per TX. Then validate the fields, access control, operations, and MVCC serially.

`t.Parallel()` was removed from `internal/bcdb` unit tests because it creates an out-of-memory failure due to too many tests with `leveldb` running together.

Signed-off-by: Yoav Tock <tock@il.ibm.com>