### PR TITLE
Update index entries structure

### DIFF
--- a/internal/blockprocessor/committer.go
+++ b/internal/blockprocessor/committer.go
@@ -366,7 +366,7 @@ func createEntriesForNewDBs(newDBs []string, dbsIndex map[string]*types.DBIndex,
 			// for each DB, if index is defined, we need to create an
 			// index DB to store index entries for that DB
 			indexDB := &worldstate.KVWithMetadata{
-				Key: stateindex.IndexDBPrefix + dbName,
+				Key: stateindex.IndexDB(dbName),
 				Metadata: &types.Metadata{
 					Version: version,
 				},
@@ -392,7 +392,7 @@ func createEntriesForIndexUpdates(
 	var err error
 
 	for dbName, dbIndex := range dbsIndex {
-		indexExist := db.Exist(stateindex.IndexDBPrefix + dbName)
+		indexExist := db.Exist(stateindex.IndexDB(dbName))
 		deleteExistingIndex := dbIndex == nil || dbIndex.GetAttributeAndType() == nil
 
 		updateDBIndex := &worldstate.KVWithMetadata{
@@ -406,7 +406,7 @@ func createEntriesForIndexUpdates(
 		if !indexExist && deleteExistingIndex {
 			continue
 		} else if indexExist && deleteExistingIndex {
-			toDeleteDBs = append(toDeleteDBs, stateindex.IndexDBPrefix+dbName)
+			toDeleteDBs = append(toDeleteDBs, stateindex.IndexDB(dbName))
 		} else if indexExist && !deleteExistingIndex {
 			updateDBIndex.Value, err = json.Marshal(dbIndex.GetAttributeAndType())
 			if err != nil {
@@ -420,7 +420,7 @@ func createEntriesForIndexUpdates(
 
 			// as there is no existing index, we need to create the index database
 			indexDB := &worldstate.KVWithMetadata{
-				Key: stateindex.IndexDBPrefix + dbName,
+				Key: stateindex.IndexDB(dbName),
 				Metadata: &types.Metadata{
 					Version: version,
 				},

--- a/internal/blockprocessor/committer_test.go
+++ b/internal/blockprocessor/committer_test.go
@@ -950,10 +950,10 @@ func TestStateDBCommitterForDBBlock(t *testing.T) {
 								Key: "db6",
 							},
 							{
-								Key: stateindex.IndexDBPrefix + "db1",
+								Key: stateindex.IndexDB("db1"),
 							},
 							{
-								Key: stateindex.IndexDBPrefix + "db2",
+								Key: stateindex.IndexDB("db2"),
 							},
 						},
 					},
@@ -1097,7 +1097,7 @@ func TestStateDBCommitterForDBBlock(t *testing.T) {
 			}
 
 			for _, dbName := range tt.expectedIndexDBsBefore {
-				require.True(t, env.db.Exist(stateindex.IndexDBPrefix+dbName))
+				require.True(t, env.db.Exist(stateindex.IndexDB(dbName)))
 			}
 
 			block := &types.Block{
@@ -1132,11 +1132,11 @@ func TestStateDBCommitterForDBBlock(t *testing.T) {
 			}
 
 			for _, dbName := range tt.expectedIndexDBsAfter {
-				require.True(t, env.db.Exist(stateindex.IndexDBPrefix+dbName))
+				require.True(t, env.db.Exist(stateindex.IndexDB(dbName)))
 			}
 
 			for _, dbName := range tt.expectedNoIndexDBsAfter {
-				require.False(t, env.db.Exist(stateindex.IndexDBPrefix+dbName))
+				require.False(t, env.db.Exist(stateindex.IndexDB(dbName)))
 			}
 		})
 	}

--- a/internal/stateindex/index_entries_test.go
+++ b/internal/stateindex/index_entries_test.go
@@ -189,23 +189,23 @@ func TestConstructIndexEntries(t *testing.T) {
 				},
 			},
 			expectedIndexEntries: map[string]*worldstate.DBUpdates{
-				IndexDBPrefix + "db1": {
+				IndexDB("db1"): {
 					Writes: []*worldstate.KVWithMetadata{
 						{
-							Key: `{"a":"a1","t":0,"m":"` + PositiveNumber + `","v":"` + encoded10 + `","k":"person1"}`,
+							Key: `{"a":"a1","t":0,"m":"` + positiveNumber + `","vp":1,"v":"` + encoded10 + `","kp":1,"k":"person1"}`,
 						},
 						{
-							Key: `{"a":"a2","t":1,"m":"","v":"ten","k":"person1"}`,
+							Key: `{"a":"a2","t":1,"m":"","vp":1,"v":"ten","kp":1,"k":"person1"}`,
 						},
 						{
-							Key: `{"a":"a3","t":2,"m":"","v":true,"k":"person1"}`,
+							Key: `{"a":"a3","t":2,"m":"","vp":1,"v":true,"kp":1,"k":"person1"}`,
 						},
 					},
 				},
-				IndexDBPrefix + "db2": {
+				IndexDB("db2"): {
 					Writes: []*worldstate.KVWithMetadata{
 						{
-							Key: `{"a":"a2","t":1,"m":"","v":"eleven","k":"person2"}`,
+							Key: `{"a":"a2","t":1,"m":"","vp":1,"v":"eleven","kp":1,"k":"person2"}`,
 						},
 					},
 				},
@@ -254,28 +254,28 @@ func TestConstructIndexEntries(t *testing.T) {
 				},
 			},
 			expectedIndexEntries: map[string]*worldstate.DBUpdates{
-				IndexDBPrefix + "db1": {
+				IndexDB("db1"): {
 					Writes: []*worldstate.KVWithMetadata{
 						{
-							Key: `{"a":"a3","t":2,"m":"","v":true,"k":"person1"}`,
+							Key: `{"a":"a3","t":2,"m":"","vp":1,"v":true,"kp":1,"k":"person1"}`,
 						},
 						{
-							Key: `{"a":"a2","t":1,"m":"","v":"10","k":"person1"}`,
+							Key: `{"a":"a2","t":1,"m":"","vp":1,"v":"10","kp":1,"k":"person1"}`,
 						},
 					},
 					Deletes: []string{
-						`{"a":"a3","t":2,"m":"","v":false,"k":"person1"}`,
-						`{"a":"a2","t":1,"m":"","v":"ten","k":"person1"}`,
+						`{"a":"a3","t":2,"m":"","vp":1,"v":false,"kp":1,"k":"person1"}`,
+						`{"a":"a2","t":1,"m":"","vp":1,"v":"ten","kp":1,"k":"person1"}`,
 					},
 				},
-				IndexDBPrefix + "db2": {
+				IndexDB("db2"): {
 					Writes: []*worldstate.KVWithMetadata{
 						{
-							Key: `{"a":"a2","t":1,"m":"","v":"eleven","k":"person2"}`,
+							Key: `{"a":"a2","t":1,"m":"","vp":1,"v":"eleven","kp":1,"k":"person2"}`,
 						},
 					},
 					Deletes: []string{
-						`{"a":"a2","t":1,"m":"","v":"ten","k":"person2"}`,
+						`{"a":"a2","t":1,"m":"","vp":1,"v":"ten","kp":1,"k":"person2"}`,
 					},
 				},
 			},
@@ -313,16 +313,16 @@ func TestConstructIndexEntries(t *testing.T) {
 				},
 			},
 			expectedIndexEntries: map[string]*worldstate.DBUpdates{
-				IndexDBPrefix + "db1": {
+				IndexDB("db1"): {
 					Deletes: []string{
-						`{"a":"a1","t":0,"m":"` + PositiveNumber + `","v":"` + encoded10 + `","k":"person1"}`,
-						`{"a":"a2","t":1,"m":"","v":"ten","k":"person1"}`,
-						`{"a":"a3","t":2,"m":"","v":true,"k":"person1"}`,
+						`{"a":"a1","t":0,"m":"` + positiveNumber + `","vp":1,"v":"` + encoded10 + `","kp":1,"k":"person1"}`,
+						`{"a":"a2","t":1,"m":"","vp":1,"v":"ten","kp":1,"k":"person1"}`,
+						`{"a":"a3","t":2,"m":"","vp":1,"v":true,"kp":1,"k":"person1"}`,
 					},
 				},
-				IndexDBPrefix + "db2": {
+				IndexDB("db2"): {
 					Deletes: []string{
-						`{"a":"a2","t":1,"m":"","v":"eleven","k":"person2"}`,
+						`{"a":"a2","t":1,"m":"","vp":1,"v":"eleven","kp":1,"k":"person2"}`,
 					},
 				},
 			},
@@ -355,7 +355,7 @@ func TestIndexEntriesForNewValues(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		kvs                  []*worldstate.KVWithMetadata
-		expectedIndexEntries []*indexEntry
+		expectedIndexEntries []*IndexEntry
 	}{
 		{
 			name: "non-json values",
@@ -397,20 +397,24 @@ func TestIndexEntriesForNewValues(t *testing.T) {
 					Value: []byte(`{"age": 26}`),
 				},
 			},
-			expectedIndexEntries: []*indexEntry{
+			expectedIndexEntries: []*IndexEntry{
 				{
-					Attribute: "age",
-					Type:      types.Type_NUMBER,
-					Metadata:  PositiveNumber,
-					Value:     encoded25,
-					Key:       "person1",
+					Attribute:     "age",
+					Type:          types.Type_NUMBER,
+					Metadata:      positiveNumber,
+					ValuePosition: Existing,
+					Value:         encoded25,
+					KeyPosition:   Existing,
+					Key:           "person1",
 				},
 				{
-					Attribute: "age",
-					Type:      types.Type_NUMBER,
-					Metadata:  PositiveNumber,
-					Value:     encoded26,
-					Key:       "person2",
+					Attribute:     "age",
+					Type:          types.Type_NUMBER,
+					Metadata:      positiveNumber,
+					ValuePosition: Existing,
+					Value:         encoded26,
+					KeyPosition:   Existing,
+					Key:           "person2",
 				},
 			},
 		},
@@ -440,7 +444,7 @@ func TestIndexEntriesOfExistingValues(t *testing.T) {
 		setup                func(db worldstate.DB)
 		dbName               string
 		deletedKeys          []string
-		expectedIndexEntries []*indexEntry
+		expectedIndexEntries []*IndexEntry
 	}{
 		{
 			name: "non-json values",
@@ -517,34 +521,42 @@ func TestIndexEntriesOfExistingValues(t *testing.T) {
 			},
 			dbName:      worldstate.DefaultDBName,
 			deletedKeys: []string{"person1", "person2", "person3", "person4"},
-			expectedIndexEntries: []*indexEntry{
+			expectedIndexEntries: []*IndexEntry{
 				{
-					Attribute: "age",
-					Type:      types.Type_NUMBER,
-					Metadata:  PositiveNumber,
-					Value:     encoded25,
-					Key:       "person1",
+					Attribute:     "age",
+					Type:          types.Type_NUMBER,
+					Metadata:      positiveNumber,
+					ValuePosition: Existing,
+					Value:         encoded25,
+					KeyPosition:   Existing,
+					Key:           "person1",
 				},
 				{
-					Attribute: "age",
-					Type:      types.Type_NUMBER,
-					Metadata:  NegativeNumber,
-					Value:     encodedNegative26,
-					Key:       "person2",
+					Attribute:     "age",
+					Type:          types.Type_NUMBER,
+					Metadata:      negativeNumber,
+					ValuePosition: Existing,
+					Value:         encodedNegative26,
+					KeyPosition:   Existing,
+					Key:           "person2",
 				},
 				{
-					Attribute: "age",
-					Type:      types.Type_NUMBER,
-					Metadata:  PositiveNumber,
-					Value:     encoded0,
-					Key:       "person3",
+					Attribute:     "age",
+					Type:          types.Type_NUMBER,
+					Metadata:      positiveNumber,
+					ValuePosition: Existing,
+					Value:         encoded0,
+					KeyPosition:   Existing,
+					Key:           "person3",
 				},
 				{
-					Attribute: "age",
-					Type:      types.Type_NUMBER,
-					Metadata:  PositiveNumber,
-					Value:     encodedMax,
-					Key:       "person4",
+					Attribute:     "age",
+					Type:          types.Type_NUMBER,
+					Metadata:      positiveNumber,
+					ValuePosition: Existing,
+					Value:         encodedMax,
+					KeyPosition:   Existing,
+					Key:           "person4",
 				},
 			},
 		},
@@ -564,22 +576,28 @@ func TestIndexEntriesOfExistingValues(t *testing.T) {
 func TestPartialIndexEntriesForValue(t *testing.T) {
 	encoded10 := encodeOrderPreservingVarUint64(uint64(10))
 	expectedIndexEntries :=
-		[]*indexEntry{
+		[]*IndexEntry{
 			{
-				Attribute: "a1",
-				Type:      types.Type_NUMBER,
-				Metadata:  PositiveNumber,
-				Value:     encoded10,
+				Attribute:     "a1",
+				Type:          types.Type_NUMBER,
+				Metadata:      positiveNumber,
+				ValuePosition: Existing,
+				Value:         encoded10,
+				KeyPosition:   Existing,
 			},
 			{
-				Attribute: "a2",
-				Type:      types.Type_STRING,
-				Value:     "female",
+				Attribute:     "a2",
+				Type:          types.Type_STRING,
+				ValuePosition: Existing,
+				Value:         "female",
+				KeyPosition:   Existing,
 			},
 			{
-				Attribute: "a3",
-				Type:      types.Type_BOOLEAN,
-				Value:     true,
+				Attribute:     "a3",
+				Type:          types.Type_BOOLEAN,
+				ValuePosition: Existing,
+				Value:         true,
+				KeyPosition:   Existing,
 			},
 		}
 
@@ -719,38 +737,38 @@ func TestRemoveDuplicateIndexEntries(t *testing.T) {
 		{
 			name: "no duplicates",
 			indexOfNewValues: []string{
-				`{"a":"age","type":0,"v":25,"k":"person1"}`,
-				`{"a":"age","type":0,"v":25,"k":"person2"}`,
-				`{"a":"age","type":0,"v":26,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
 			},
 			indexOfExistingValues: []string{
-				`{"a":"age","type":0,"v":26,"k":"person1"}`,
-				`{"a":"age","type":0,"v":27,"k":"person2"}`,
-				`{"a":"age","type":0,"v":28,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":1,"v":27,"kp":1,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":1,"v":28,"kp":1,"k":"person3"}`,
 			},
 			expectedIndexOfNewValues: []string{
-				`{"a":"age","type":0,"v":25,"k":"person1"}`,
-				`{"a":"age","type":0,"v":25,"k":"person2"}`,
-				`{"a":"age","type":0,"v":26,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
 			},
 			expectedIndexOfExistingValues: []string{
-				`{"a":"age","type":0,"v":26,"k":"person1"}`,
-				`{"a":"age","type":0,"v":27,"k":"person2"}`,
-				`{"a":"age","type":0,"v":28,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":1,"v":27,"kp":1,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":1,"v":28,"kp":1,"k":"person3"}`,
 			},
 		},
 		{
 			name: "no duplicates as there is no existing value",
 			indexOfNewValues: []string{
-				`{"a":"age","type":0,"v":25,"k":"person1"}`,
-				`{"a":"age","type":0,"v":25,"k":"person2"}`,
-				`{"a":"age","type":0,"v":26,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
 			},
 			indexOfExistingValues: []string{},
 			expectedIndexOfNewValues: []string{
-				`{"a":"age","type":0,"v":25,"k":"person1"}`,
-				`{"a":"age","type":0,"v":25,"k":"person2"}`,
-				`{"a":"age","type":0,"v":26,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
 			},
 			expectedIndexOfExistingValues: []string{},
 		},
@@ -758,47 +776,47 @@ func TestRemoveDuplicateIndexEntries(t *testing.T) {
 			name:             "no duplicates as the new value is empty",
 			indexOfNewValues: []string{},
 			indexOfExistingValues: []string{
-				`{"a":"age","type":0,"v":26,"k":"person1"}`,
-				`{"a":"age","type":0,"v":27,"k":"person2"}`,
-				`{"a":"age","type":0,"v":28,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":1,"v":27,"kp":1,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":1,"v":28,"kp":1,"k":"person3"}`,
 			},
 			expectedIndexOfNewValues: []string{},
 			expectedIndexOfExistingValues: []string{
-				`{"a":"age","type":0,"v":26,"k":"person1"}`,
-				`{"a":"age","type":0,"v":27,"k":"person2"}`,
-				`{"a":"age","type":0,"v":28,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":1,"v":27,"kp":1,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":1,"v":28,"kp":1,"k":"person3"}`,
 			},
 		},
 		{
 			name: "two duplicate entries",
 			indexOfNewValues: []string{
-				`{"a":"age","type":0,"v":25,"k":"person1"}`,
-				`{"a":"age","type":0,"v":25,"k":"person2"}`,
-				`{"a":"age","type":0,"v":26,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
 			},
 			indexOfExistingValues: []string{
-				`{"a":"age","type":0,"v":26,"k":"person1"}`,
-				`{"a":"age","type":0,"v":25,"k":"person2"}`,
-				`{"a":"age","type":0,"v":26,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
 			},
 			expectedIndexOfNewValues: []string{
-				`{"a":"age","type":0,"v":25,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
 			},
 			expectedIndexOfExistingValues: []string{
-				`{"a":"age","type":0,"v":26,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person1"}`,
 			},
 		},
 		{
 			name: "all are duplicate entries",
 			indexOfNewValues: []string{
-				`{"a":"age","type":0,"v":25,"k":"person1"}`,
-				`{"a":"age","type":0,"v":25,"k":"person2"}`,
-				`{"a":"age","type":0,"v":26,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
 			},
 			indexOfExistingValues: []string{
-				`{"a":"age","type":0,"v":25,"k":"person1"}`,
-				`{"a":"age","type":0,"v":25,"k":"person2"}`,
-				`{"a":"age","type":0,"v":26,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
 			},
 			expectedIndexOfNewValues:      []string{},
 			expectedIndexOfExistingValues: []string{},


### PR DESCRIPTION
To enable logical operations such as <, >, <=, >=, we introduce
two additional fields in the index entry: ValuePosition and
KeyPosition.

Further, we unexport certain fields/functions and export some
which are to be used by query executor package