### PR TITLE
Take snapshots & restart from snapshot

### DIFF
--- a/internal/replication/blockreplicator_3node_test.go
+++ b/internal/replication/blockreplicator_3node_test.go
@@ -1,13 +1,13 @@
 package replication_test
 
 import (
-	"github.com/golang/protobuf/proto"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/replication/env_test.go
+++ b/internal/replication/env_test.go
@@ -155,7 +155,7 @@ func (n *nodeEnv) ServeCommit() {
 			block2commit := b.(*types.Block)
 			err = n.ledger.Append(block2commit)
 			if err != nil {
-				lg.Errorf("Stopping to serve commit loop, error: %s", err)
+				lg.Panicf("Stopping to serve commit loop, error: %s", err)
 				return
 			}
 			switch block2commit.Payload.(type) {


### PR DESCRIPTION
This commit:
    - Adds code that allows each single node to create a stream of snapshots based on accumulated size criteria.
    - The last 4 snapshots are saved, older snapshots are purged.
    - The WAL is also pruned (compacted) when a snapshot is created.
    - A single node can restart from its own snapshot.

    However:
    - Catch up between leader and follower not supported yet. Therefore,
    - For a cluster scenario use snapshot-inteval that will never cause a snapshot, e.g. max-int64.