### PR TITLE
Flaky test: block replicator timeout

### DIFF
--- a/internal/replication/blockreplicator_test.go
+++ b/internal/replication/blockreplicator_test.go
@@ -225,6 +225,8 @@ func TestBlockReplicator_Submit(t *testing.T) {
 		wg.Add(1)
 
 		submitManyTillClosed := func() {
+			defer wg.Done()
+
 			for i := 0; i < 1000; i++ { // larger than the raft pipeline
 				block := &types.Block{
 					Header: &types.BlockHeader{
@@ -240,7 +242,6 @@ func TestBlockReplicator_Submit(t *testing.T) {
 					require.NoError(t, err)
 				}
 				if err != nil {
-					wg.Done()
 					switch err.(type) {
 					case *ierrors.NotLeaderError:
 						require.EqualError(t, err, "not a leader, leader is: 0")
@@ -366,4 +367,3 @@ func TestBlockReplicator_Submit(t *testing.T) {
 		env.conf.Transport.Close()
 	})
 }
-


### PR DESCRIPTION
Normally the block replicator ingests about 100 blocks before it is closed.
However, in rare scheduling conditions the loop will end submitting 1000 blocks
before the block-replicator is closed. The wg.Done() in blockreplicator_test.go
L:227 function submitManyTillClosed was located in the wrong place for that rare event.

Its location was changed to handle this case as well.

Signed-off-by: Yoav Tock <tock@il.ibm.com>