### PR TITLE
Allow config updates to Admins & CAs

### DIFF
--- a/internal/replication/utils.go
+++ b/internal/replication/utils.go
@@ -5,10 +5,12 @@ package replication
 
 import (
 	"fmt"
+	"hash/crc64"
+
 	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+	"github.com/golang/protobuf/proto"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"
-	"hash/crc64"
 )
 
 func raftPeers(config *types.ClusterConfig) []raft.Peer {
@@ -24,4 +26,63 @@ func raftEntryString(e raftpb.Entry) string {
 	h.Write(e.Data)
 	return fmt.Sprintf("{Term:%d Index:%d Type:%v Data(len):%d Data(hash):%X}",
 		e.Term, e.Index, e.Type, len(e.Data), h.Sum64())
+}
+
+// ClassifyClusterReConfig detects the kind of changes that happened in the ClusterConfig.
+func ClassifyClusterReConfig(currentConfig, updatedConfig *types.ClusterConfig) (nodes bool, consensus bool, ca bool, admins bool) {
+	nodes = changedNodes(currentConfig.GetNodes(), updatedConfig.GetNodes())
+
+	curConsensus := currentConfig.GetConsensusConfig()
+	updConsensus := updatedConfig.GetConsensusConfig()
+	consensus = !proto.Equal(curConsensus, updConsensus)
+
+	curCA := currentConfig.GetCertAuthConfig()
+	updCA := updatedConfig.GetCertAuthConfig()
+	ca = !proto.Equal(curCA, updCA)
+
+	admins = changedAdmins(currentConfig.GetAdmins(), updatedConfig.GetAdmins())
+
+	return nodes, consensus, ca, admins
+}
+
+func changedAdmins(curAdmins []*types.Admin, updAdmins []*types.Admin) bool {
+	if len(curAdmins) != len(updAdmins) {
+		return true
+	}
+
+	for _, curA := range curAdmins {
+		found := false
+		for _, updA := range updAdmins {
+			if proto.Equal(curA, updA) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return true
+		}
+	}
+
+	return false
+}
+
+func changedNodes(curNodes []*types.NodeConfig, updNodes []*types.NodeConfig) bool {
+	if len(curNodes) != len(updNodes) {
+		return true
+	}
+
+	for _, curN := range curNodes {
+		found := false
+		for _, updN := range updNodes {
+			if proto.Equal(curN, updN) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
Dynamic config of ClusterConfig is currently not supported and causes panic.
This commit allows config changes to ClusterConfig.Admins and ClusterConfig.CertAuthConfig,
as those have no effect on the replication component.

The server will panic if ClusterConfig.Nodes or ClusterConfig.ConsensusConfig are changed.
This will change once dynamic reconfig of consensus related objects is implemented.

Signed-off-by: Yoav Tock <tock@il.ibm.com>