### PR TITLE
Mptrie proof api moving to pkg

### DIFF
--- a/internal/bcdb/ledger_query_procesor.go
+++ b/internal/bcdb/ledger_query_procesor.go
@@ -5,6 +5,8 @@ package bcdb
 import (
 	"fmt"
 
+	"github.com/IBM-Blockchain/bcdb-server/pkg/state"
+
 	"github.com/IBM-Blockchain/bcdb-server/internal/blockstore"
 	interrors "github.com/IBM-Blockchain/bcdb-server/internal/errors"
 	"github.com/IBM-Blockchain/bcdb-server/internal/identity"
@@ -140,7 +142,7 @@ func (p *ledgerQueryProcessor) getDataProof(userId string, blockNum uint64, dbna
 	if err != nil {
 		return nil, err
 	}
-	trieKey, err := mptrie.ConstructCompositeKey(dbname, key)
+	trieKey, err := state.ConstructCompositeKey(dbname, key)
 	if err != nil {
 		return nil, err
 	}
@@ -155,14 +157,9 @@ func (p *ledgerQueryProcessor) getDataProof(userId string, blockNum uint64, dbna
 	}
 
 	resp := &types.GetDataProofResponse{
-		Path: make([]*types.MPTrieProofElement, 0),
+		Path: proof.GetPath(),
 	}
 
-	for _, pathStep := range proof.GetPath() {
-		resp.Path = append(resp.Path, &types.MPTrieProofElement{
-			Hashes: pathStep,
-		})
-	}
 	return resp, nil
 }
 

--- a/internal/bcdb/ledger_query_procesor_test.go
+++ b/internal/bcdb/ledger_query_procesor_test.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/IBM-Blockchain/bcdb-server/pkg/state"
+
 	"github.com/IBM-Blockchain/bcdb-server/internal/blockprocessor"
 	"github.com/IBM-Blockchain/bcdb-server/internal/blockstore"
 	interrors "github.com/IBM-Blockchain/bcdb-server/internal/errors"
@@ -731,17 +733,13 @@ func TestGetDataProof(t *testing.T) {
 			if testCase.expectedErr == nil {
 				require.NoError(t, err)
 				require.NotNil(t, proof)
-				proofPath := make([]mptrie.NodeBytes, 0)
-				for _, segment := range proof.Path {
-					proofPath = append(proofPath, segment.Hashes)
-				}
-				mpTrieProof := mptrie.NewProof(proofPath)
-				trieKey, err := mptrie.ConstructCompositeKey(worldstate.DefaultDBName, testCase.key)
+				mpTrieProof := state.NewProof(proof.Path)
+				trieKey, err := state.ConstructCompositeKey(worldstate.DefaultDBName, testCase.key)
 				require.NoError(t, err)
-				kvHash, err := mptrie.CalculateKeyValueHash(trieKey, testCase.value)
+				kvHash, err := state.CalculateKeyValueHash(trieKey, testCase.value)
 				rootHash := env.blocks[testCase.blockNumber-1].StateMerkelTreeRootHash
 				require.NoError(t, err)
-				isValid, err := mpTrieProof.Validate(kvHash, rootHash, testCase.isDeleted)
+				isValid, err := mpTrieProof.Verify(kvHash, rootHash, testCase.isDeleted)
 				require.NoError(t, err)
 				require.Equal(t, testCase.isValid, isValid)
 			} else {

--- a/internal/bcdb/transaction_processor_test.go
+++ b/internal/bcdb/transaction_processor_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/IBM-Blockchain/bcdb-server/pkg/state"
+
 	"github.com/IBM-Blockchain/bcdb-server/config"
 	"github.com/IBM-Blockchain/bcdb-server/internal/blockprocessor"
 	"github.com/IBM-Blockchain/bcdb-server/internal/blockstore"
@@ -720,7 +722,7 @@ func applyTxsOnTrie(t *testing.T, env *txProcessorTestEnv, payload interface{}, 
 
 	for dbName, update := range dbUpdates {
 		for _, dbwrite := range update.Writes {
-			key, err := mptrie.ConstructCompositeKey(dbName, dbwrite.Key)
+			key, err := state.ConstructCompositeKey(dbName, dbwrite.Key)
 			require.NoError(t, err)
 			// TODO: should we add Metadata to value
 			value := dbwrite.Value
@@ -728,7 +730,7 @@ func applyTxsOnTrie(t *testing.T, env *txProcessorTestEnv, payload interface{}, 
 			require.NoError(t, err)
 		}
 		for _, dbdelete := range update.Deletes {
-			key, err := mptrie.ConstructCompositeKey(dbName, dbdelete)
+			key, err := state.ConstructCompositeKey(dbName, dbdelete)
 			require.NoError(t, err)
 			_, err = stateTrie.Delete(key)
 			require.NoError(t, err)

--- a/internal/blockprocessor/committer.go
+++ b/internal/blockprocessor/committer.go
@@ -5,6 +5,8 @@ package blockprocessor
 import (
 	"encoding/json"
 
+	"github.com/IBM-Blockchain/bcdb-server/pkg/state"
+
 	"github.com/IBM-Blockchain/bcdb-server/internal/blockstore"
 	"github.com/IBM-Blockchain/bcdb-server/internal/identity"
 	"github.com/IBM-Blockchain/bcdb-server/internal/mptrie"
@@ -264,7 +266,7 @@ func (c *committer) commitTrie(height uint64) error {
 func ApplyBlockOnStateTrie(trie *mptrie.MPTrie, worldStateUpdates map[string]*worldstate.DBUpdates) error {
 	for dbName, dbUpdate := range worldStateUpdates {
 		for _, dbWrite := range dbUpdate.Writes {
-			key, err := mptrie.ConstructCompositeKey(dbName, dbWrite.Key)
+			key, err := state.ConstructCompositeKey(dbName, dbWrite.Key)
 			if err != nil {
 				return err
 			}
@@ -276,7 +278,7 @@ func ApplyBlockOnStateTrie(trie *mptrie.MPTrie, worldStateUpdates map[string]*wo
 			}
 		}
 		for _, dbDelete := range dbUpdate.Deletes {
-			key, err := mptrie.ConstructCompositeKey(dbName, dbDelete)
+			key, err := state.ConstructCompositeKey(dbName, dbDelete)
 			if err != nil {
 				return err
 			}

--- a/internal/blockprocessor/processor_test.go
+++ b/internal/blockprocessor/processor_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/IBM-Blockchain/bcdb-server/pkg/state"
+
 	"github.com/IBM-Blockchain/bcdb-server/internal/blockprocessor/mocks"
 	"github.com/IBM-Blockchain/bcdb-server/internal/blockstore"
 	"github.com/IBM-Blockchain/bcdb-server/internal/identity"
@@ -425,7 +427,7 @@ func TestValidatorAndCommitter(t *testing.T) {
 			}
 
 			assertCommittedValue := func() bool {
-				stateTrieKey, err := mptrie.ConstructCompositeKey(worldstate.DefaultDBName, "key1")
+				stateTrieKey, err := state.ConstructCompositeKey(worldstate.DefaultDBName, "key1")
 				if err != nil {
 					return false
 				}
@@ -433,11 +435,11 @@ func TestValidatorAndCommitter(t *testing.T) {
 				if err != nil || proof == nil {
 					return false
 				}
-				kvHash, err := mptrie.CalculateKeyValueHash(stateTrieKey, tt.expectedValue)
+				kvHash, err := state.CalculateKeyValueHash(stateTrieKey, tt.expectedValue)
 				if err != nil {
 					return false
 				}
-				valid, err := proof.Validate(kvHash, tt.expectedBlocks[tt.expectedBlockHeight-2].Header.StateMerkelTreeRootHash, false)
+				valid, err := proof.Verify(kvHash, tt.expectedBlocks[tt.expectedBlockHeight-2].Header.StateMerkelTreeRootHash, false)
 				if err != nil || !valid {
 					return false
 				}

--- a/internal/mptrie/mptrie.go
+++ b/internal/mptrie/mptrie.go
@@ -6,7 +6,8 @@ import (
 	"bytes"
 	"sync"
 
-	"github.com/IBM-Blockchain/bcdb-server/pkg/crypto"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/state"
+
 	"github.com/pkg/errors"
 )
 
@@ -103,7 +104,7 @@ func (t *MPTrie) Update(key, value []byte) error {
 	if len(key) == 0 {
 		return errors.New("can't update element with empty key")
 	}
-	valuePtr, err := CalculateKeyValueHash(key, value)
+	valuePtr, err := state.CalculateKeyValueHash(key, value)
 	if err != nil {
 		return err
 	}
@@ -611,43 +612,9 @@ func findCommonPrefix(hexKey1, hexKey2 []byte) []byte {
 	return res
 }
 
-func CalculateKeyValueHash(key, value []byte) ([]byte, error) {
-	bytesToHash := make([]byte, 0)
-	if len(key) > 0 {
-		bytesToHash = append(bytesToHash, key...)
-	}
-	if len(value) > 0 {
-		valHash, err := crypto.ComputeSHA256Hash(value)
-		if err != nil {
-			return nil, err
-		}
-		bytesToHash = append(bytesToHash, valHash...)
-	}
-	return crypto.ComputeSHA256Hash(bytesToHash)
-}
-
 func min(a, b int) int {
 	if a > b {
 		return b
 	}
 	return a
-}
-
-func ConstructCompositeKey(dbName, key string) ([]byte, error) {
-	bytesToHash := make([]byte, 0)
-	if len(dbName) > 0 {
-		dbNameHash, err := crypto.ComputeSHA256Hash([]byte(dbName))
-		if err != nil {
-			return nil, err
-		}
-		bytesToHash = append(bytesToHash, dbNameHash...)
-	}
-	if len(key) > 0 {
-		keyHash, err := crypto.ComputeSHA256Hash([]byte(key))
-		if err != nil {
-			return nil, err
-		}
-		bytesToHash = append(bytesToHash, keyHash...)
-	}
-	return crypto.ComputeSHA256Hash(bytesToHash)
 }

--- a/internal/mptrie/node.go
+++ b/internal/mptrie/node.go
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package mptrie
 
-import "github.com/IBM-Blockchain/bcdb-server/pkg/crypto"
+import (
+	"github.com/IBM-Blockchain/bcdb-server/pkg/state"
+)
 
 type TrieNode interface {
 	hash() ([]byte, error)
@@ -16,10 +18,8 @@ type TrieNodeWithValue interface {
 	isDeleted() bool
 }
 
-var deleteBytes = []byte{1}
-
 func (m *BranchNode) hash() ([]byte, error) {
-	return calcHash(m.bytes())
+	return state.CalcHash(m.bytes())
 }
 
 func (m *BranchNode) bytes() [][]byte {
@@ -30,7 +30,7 @@ func (m *BranchNode) bytes() [][]byte {
 		bytes = append(bytes, m.ValuePtr)
 	}
 	if m.isDeleted() {
-		bytes = append(bytes, deleteBytes)
+		bytes = append(bytes, state.KeyDeleteMarkerBytes)
 	}
 	return bytes
 }
@@ -48,7 +48,7 @@ func (m *BranchNode) isDeleted() bool {
 }
 
 func (m *ExtensionNode) hash() ([]byte, error) {
-	return calcHash(m.bytes())
+	return state.CalcHash(m.bytes())
 }
 
 func (m *ExtensionNode) bytes() [][]byte {
@@ -63,7 +63,7 @@ func (m *ExtensionNode) bytes() [][]byte {
 }
 
 func (m *ValueNode) hash() ([]byte, error) {
-	return calcHash(m.bytes())
+	return state.CalcHash(m.bytes())
 }
 
 func (m *ValueNode) bytes() [][]byte {
@@ -75,7 +75,7 @@ func (m *ValueNode) bytes() [][]byte {
 		bytes = append(bytes, m.ValuePtr)
 	}
 	if m.isDeleted() {
-		bytes = append(bytes, deleteBytes)
+		bytes = append(bytes, state.KeyDeleteMarkerBytes)
 	}
 	return bytes
 }
@@ -98,12 +98,4 @@ func (m *EmptyNode) hash() ([]byte, error) {
 
 func (m *EmptyNode) bytes() [][]byte {
 	panic("can't hash empty node")
-}
-
-func calcHash(bytes [][]byte) ([]byte, error) {
-	bytesToHash := make([]byte, 0)
-	for _, b := range bytes {
-		bytesToHash = append(bytesToHash, b...)
-	}
-	return crypto.ComputeSHA256Hash(bytesToHash)
 }

--- a/internal/mptrie/proof.go
+++ b/internal/mptrie/proof.go
@@ -1,24 +1,14 @@
 package mptrie
 
 import (
-	"bytes"
-
-	"github.com/pkg/errors"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/state"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
 )
-
-type NodeBytes [][]byte
-
-type Proof struct {
-	// For each node in trie path, it contains bytes of all node fields and []byte{1} in case of deleted flag true
-	// Path is from rom node contains value to root node
-	// Exactly same byte slices used to calculate node hash.
-	path []NodeBytes
-}
 
 // GetProof calculates proof (path) from node contains value to root node in trie
 // for given key and delete flag, i.e. if value was deleted, but delete flag id false,
 // no proof will be calculated
-func (t *MPTrie) GetProof(key []byte, isDeleted bool) (*Proof, error) {
+func (t *MPTrie) GetProof(key []byte, isDeleted bool) (*state.Proof, error) {
 	hexKey := convertByteToHex(key)
 	path, node, err := t.getPath(hexKey)
 
@@ -34,69 +24,13 @@ func (t *MPTrie) GetProof(key []byte, isDeleted bool) (*Proof, error) {
 		return nil, nil
 	}
 
-	res := &Proof{
-		path: make([]NodeBytes, 0),
-	}
+	resPath := make([]*types.MPTrieProofElement, 0)
 	for i := len(path) - 1; i >= 0; i-- {
 		node := path[i]
-		res.path = append(res.path, node.bytes())
+		resPath = append(resPath, &types.MPTrieProofElement{
+			Hashes: node.bytes(),
+		})
 	}
 
-	return res, nil
-}
-
-func (p *Proof) Validate(leafHash, rootHash []byte, isDeleted bool) (bool, error) {
-	pathLen := len(p.path)
-
-	if pathLen == 0 {
-		return false, errors.New("proof can't be empty")
-	}
-
-	// In case deleted value, node that contains it should contain []byte{1} between its hashes/bytes
-	if isDeleted {
-		isDeleteFound := false
-		for _, hash := range p.path[0] {
-			if bytes.Equal(hash, deleteBytes) {
-				isDeleteFound = true
-				break
-			}
-		}
-		if !isDeleteFound {
-			return false, nil
-		}
-	}
-
-	hashToFind := leafHash
-
-	// Validation algorithm just checks is hashToFind (current node/value hash) is part of hashes/bytes
-	// list in node above. We start from value hash (leafHash) and continue to root stored in block
-	for i := 0; i < pathLen; i++ {
-		isHashFound := false
-		for _, hash := range p.path[i] {
-			if bytes.Equal(hash, hashToFind) {
-				isHashFound = true
-				break
-			}
-		}
-		if !isHashFound {
-			return false, nil
-		}
-
-		var err error
-		// hash here calculated same way as node hash calculated
-		hashToFind, err = calcHash(p.path[i])
-		if err != nil {
-			return false, err
-		}
-	}
-	// Check if calculated root hash if equal to supplied (stored in block)
-	return bytes.Equal(rootHash, hashToFind), nil
-}
-
-func (p *Proof) GetPath() []NodeBytes {
-	return p.path
-}
-
-func NewProof(path []NodeBytes) *Proof {
-	return &Proof{path: path}
+	return state.NewProof(resPath), nil
 }

--- a/internal/mptrie/proof_test.go
+++ b/internal/mptrie/proof_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/IBM-Blockchain/bcdb-server/pkg/state"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,10 +81,10 @@ func TestMPTrieGetProof(t *testing.T) {
 		proof, err := trie.GetProof(key, false)
 		require.NoError(t, err)
 		require.NotNil(t, proof)
-		valPtr, err := CalculateKeyValueHash(key, values[i])
+		valPtr, err := state.CalculateKeyValueHash(key, values[i])
 		require.NoError(t, err)
 		require.NotNil(t, valPtr)
-		isValid, err := proof.Validate(valPtr, rootHashBeforeDelete, false)
+		isValid, err := proof.Verify(valPtr, rootHashBeforeDelete, false)
 		require.NoError(t, err)
 		require.True(t, isValid, fmt.Sprintf("Key is: %s", convertKeyToHex(t, key)))
 
@@ -95,10 +97,10 @@ func TestMPTrieGetProof(t *testing.T) {
 		proof, err := trie.GetProof(key, false)
 		require.NoError(t, err)
 		require.NotNil(t, proof)
-		valPtr, err := CalculateKeyValueHash(key, []byte("TO_DELETE"))
+		valPtr, err := state.CalculateKeyValueHash(key, []byte("TO_DELETE"))
 		require.NoError(t, err)
 		require.NotNil(t, valPtr)
-		isValid, err := proof.Validate(valPtr, rootHashBeforeDelete, false)
+		isValid, err := proof.Verify(valPtr, rootHashBeforeDelete, false)
 		require.NoError(t, err)
 		require.True(t, isValid)
 
@@ -123,10 +125,10 @@ func TestMPTrieGetProof(t *testing.T) {
 		proof, err := trie.GetProof(key, false)
 		require.NoError(t, err)
 		require.NotNil(t, proof)
-		valPtr, err := CalculateKeyValueHash(key, values[i])
+		valPtr, err := state.CalculateKeyValueHash(key, values[i])
 		require.NoError(t, err)
 		require.NotNil(t, valPtr)
-		isValid, err := proof.Validate(valPtr, rootHashAfterDelete, false)
+		isValid, err := proof.Verify(valPtr, rootHashAfterDelete, false)
 		require.NoError(t, err)
 		require.True(t, isValid)
 
@@ -139,13 +141,13 @@ func TestMPTrieGetProof(t *testing.T) {
 		proof, err := trie.GetProof(key, true)
 		require.NoError(t, err)
 		require.NotNil(t, proof)
-		valPtr, err := CalculateKeyValueHash(key, []byte("TO_DELETE"))
+		valPtr, err := state.CalculateKeyValueHash(key, []byte("TO_DELETE"))
 		require.NoError(t, err)
 		require.NotNil(t, valPtr)
-		isValid, err := proof.Validate(valPtr, rootHashAfterDelete, true)
+		isValid, err := proof.Verify(valPtr, rootHashAfterDelete, true)
 		require.NoError(t, err)
 		require.True(t, isValid)
-		isValid, err = proof.Validate(valPtr, rootHashBeforeDelete, false)
+		isValid, err = proof.Verify(valPtr, rootHashBeforeDelete, false)
 		require.NoError(t, err)
 		require.False(t, isValid)
 

--- a/pkg/state/proof.go
+++ b/pkg/state/proof.go
@@ -1,0 +1,116 @@
+package state
+
+import (
+	"bytes"
+
+	"github.com/IBM-Blockchain/bcdb-server/pkg/crypto"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+	"github.com/pkg/errors"
+)
+
+var KeyDeleteMarkerBytes = []byte{1}
+
+type Proof struct {
+	// For each node in trie path, it contains bytes of all node fields and []byte{1} in case of deleted flag true
+	// path is from rom node contains value to root node
+	// Exactly same byte slices used to calculate node hash.
+	path []*types.MPTrieProofElement
+}
+
+func (p *Proof) Verify(leafHash, rootHash []byte, isDeleted bool) (bool, error) {
+	pathLen := len(p.path)
+
+	if pathLen == 0 {
+		return false, errors.New("proof can't be empty")
+	}
+
+	// In case deleted value, node that contains it should contain []byte{1} between its hashes/bytes
+	if isDeleted {
+		isDeleteFound := false
+		for _, hash := range p.path[0].GetHashes() {
+			if bytes.Equal(hash, KeyDeleteMarkerBytes) {
+				isDeleteFound = true
+				break
+			}
+		}
+		if !isDeleteFound {
+			return false, nil
+		}
+	}
+
+	hashToFind := leafHash
+
+	// Validation algorithm just checks is hashToFind (current node/value hash) is part of hashes/bytes
+	// list in node above. We start from value hash (leafHash) and continue to root stored in block
+	for i := 0; i < pathLen; i++ {
+		isHashFound := false
+		for _, hash := range p.path[i].GetHashes() {
+			if bytes.Equal(hash, hashToFind) {
+				isHashFound = true
+				break
+			}
+		}
+		if !isHashFound {
+			return false, nil
+		}
+
+		var err error
+		// hash here calculated same way as node hash calculated
+		hashToFind, err = CalcHash(p.path[i].GetHashes())
+		if err != nil {
+			return false, err
+		}
+	}
+	// Check if calculated root hash if equal to supplied (stored in block)
+	return bytes.Equal(rootHash, hashToFind), nil
+}
+
+func (p *Proof) GetPath() []*types.MPTrieProofElement {
+	return p.path
+}
+
+func NewProof(path []*types.MPTrieProofElement) *Proof {
+	return &Proof{path: path}
+}
+
+func CalcHash(bytes [][]byte) ([]byte, error) {
+	bytesToHash := make([]byte, 0)
+	for _, b := range bytes {
+		bytesToHash = append(bytesToHash, b...)
+	}
+	return crypto.ComputeSHA256Hash(bytesToHash)
+}
+
+func ConstructCompositeKey(dbName, key string) ([]byte, error) {
+	bytesToHash := make([]byte, 0)
+	if len(dbName) > 0 {
+		dbNameHash, err := crypto.ComputeSHA256Hash([]byte(dbName))
+		if err != nil {
+			return nil, err
+		}
+		bytesToHash = append(bytesToHash, dbNameHash...)
+	}
+	if len(key) > 0 {
+		keyHash, err := crypto.ComputeSHA256Hash([]byte(key))
+		if err != nil {
+			return nil, err
+		}
+		bytesToHash = append(bytesToHash, keyHash...)
+	}
+	return crypto.ComputeSHA256Hash(bytesToHash)
+}
+
+func CalculateKeyValueHash(key, value []byte) ([]byte, error) {
+	bytesToHash := make([]byte, 0)
+	if len(key) > 0 {
+		bytesToHash = append(bytesToHash, key...)
+	}
+	if len(value) > 0 {
+		valHash, err := crypto.ComputeSHA256Hash(value)
+		if err != nil {
+			return nil, err
+		}
+		bytesToHash = append(bytesToHash, valHash...)
+	}
+	return crypto.ComputeSHA256Hash(bytesToHash)
+}


### PR DESCRIPTION
Moving internal `mptrie.Proof` struct to pkg `state.Proof` with all relevant methods. 

To make it available to sdk.