### PR TITLE
Catchup client

### DIFF
--- a/internal/comm/catchup_client.go
+++ b/internal/comm/catchup_client.go
@@ -1,0 +1,272 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package comm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/IBM-Blockchain/bcdb-server/internal/httputils"
+	"io/ioutil"
+	"math/rand"
+	"mime"
+	"mime/multipart"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/IBM-Blockchain/bcdb-server/pkg/logger"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+)
+
+var RetryIntervalMin = 10 * time.Millisecond
+var RetryIntervalMax = 10 * time.Second
+
+type catchUpClient struct {
+	httpClient *http.Client
+	logger     *logger.SugarLogger
+
+	mutex   sync.Mutex
+	members map[uint64]*url.URL
+}
+
+func NewCatchUpClient(lg *logger.SugarLogger) *catchUpClient {
+	c := &catchUpClient{
+		httpClient: newHTTPClient(),
+		logger:     lg,
+		members:    make(map[uint64]*url.URL),
+	}
+	return c
+}
+
+// UpdateMembers updates the peer member list, must not include the self RaftID.
+func (c *catchUpClient) UpdateMembers(memberList []*types.PeerConfig) error {
+	members := make(map[uint64]*url.URL)
+	for _, m := range memberList {
+		rawURL := fmt.Sprintf("http://%s:%d", m.PeerHost, m.PeerPort) //TODO insecure for now, add security later
+		baseURL, err := url.Parse(rawURL)
+		if err != nil {
+			return errors.Wrapf(err, "failed to convert PeerConfig [%+v] to url", m)
+		}
+		if m.RaftId == 0 {
+			return errors.Errorf("raft ID cannot be 0, PeerConfig: [%+v]", m)
+		}
+		members[m.RaftId] = baseURL
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.members = members
+
+	return nil
+}
+
+func (c *catchUpClient) PullBlocks(ctx context.Context, start, end uint64, leaderHint uint64) ([]*types.Block, error) {
+	curRetryInterval := RetryIntervalMin
+
+	var rounds uint64
+	for {
+		var memberIDs []uint64
+		if leaderHint != 0 {
+			memberIDs = append(memberIDs, leaderHint)
+		}
+		memberIDs = append(memberIDs, c.memberIDs()...)
+		c.logger.Debugf("going to try getting blocks [%d,%d] from members: %v, in that order", start, end, memberIDs)
+
+		for _, id := range memberIDs {
+			select {
+			case <-ctx.Done():
+				c.logger.Infof("PulledBlocks canceled: %s", ctx.Err())
+				return nil, errors.WithMessage(ctx.Err(), "PullBlocks canceled")
+			default:
+				blocks, err := c.GetBlocks(ctx, id, start, end)
+				if err != nil {
+					c.logger.Debugf("failed to get blocks from member [%d], error: %s", id, err)
+					continue
+				}
+
+				last := blocks[len(blocks)-1].Header.BaseHeader.Number
+				c.logger.Infof("Pulled blocks [%d,%d] from member [%d]", start, last, id)
+				return blocks, nil
+			}
+		}
+
+		rounds++
+		c.logger.Debugf("Round %d failed to get blocks [%d,%d] from members, will try again in %s", rounds, start, end, curRetryInterval)
+		if leaderHint != 0 {
+			c.logger.Debugf("Hinted leader [%d] is not responsive, hint will not be used again", leaderHint)
+			leaderHint = 0
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, errors.WithMessage(ctx.Err(), "PullBlocks canceled")
+		case <-time.After(curRetryInterval):
+			// double the retry interval up to a max, to implement exponential back-off
+			curRetryInterval = 2 * curRetryInterval
+			if curRetryInterval > RetryIntervalMax {
+				curRetryInterval = RetryIntervalMax
+				c.logger.Debugf("Retry interval max reached: %v", curRetryInterval)
+			}
+		}
+	}
+}
+
+func (c *catchUpClient) memberIDs() []uint64 {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	var ids []uint64
+	for k, _ := range c.members {
+		ids = append(ids, k)
+	}
+
+	rand.Shuffle(len(ids), func(i, j int) { ids[i], ids[j] = ids[j], ids[i] })
+
+	return ids
+}
+
+func (c *catchUpClient) getMemberURL(target uint64) *url.URL {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	return c.members[target]
+}
+
+func (c *catchUpClient) GetBlocks(ctx context.Context, targetID, start, end uint64) ([]*types.Block, error) {
+	baseURL := c.getMemberURL(targetID)
+	if baseURL == nil {
+		return nil, errors.Errorf("target ID [%d] not found", targetID)
+	}
+
+	q := make(url.Values)
+	q.Add("start", strconv.FormatUint(start, 10))
+	q.Add("end", strconv.FormatUint(end, 10))
+	url := baseURL.ResolveReference(
+		&url.URL{
+			Path:     GetBlocksPath,
+			RawQuery: q.Encode(),
+		},
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil) //TODO add context for fast server shutdown
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", httputils.MultiPartFormData)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		eRes := &types.HttpResponseErr{}
+		if err = json.NewDecoder(resp.Body).Decode(eRes); err != nil {
+			return nil, err
+		}
+		return nil, eRes
+	}
+
+	return multipartResponseToBlocks(c.logger, resp)
+}
+
+func (c *catchUpClient) GetHeight(ctx context.Context, targetID uint64) (uint64, error) {
+	baseURL := c.getMemberURL(targetID)
+	if baseURL == nil {
+		return 0, errors.Errorf("target ID [%d] not found", targetID)
+	}
+
+	url := baseURL.ResolveReference(&url.URL{Path: GetHeightPath})
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Add("Accept", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		eRes := &types.HttpResponseErr{}
+		if err = json.NewDecoder(resp.Body).Decode(eRes); err != nil {
+			return 0, err
+		}
+		return 0, eRes
+	}
+
+	hRes := &HeightResponse{}
+	if err = json.NewDecoder(resp.Body).Decode(hRes); err != nil {
+		return 0, err
+	}
+
+	return hRes.Height, nil
+}
+
+func newHTTPClient() *http.Client {
+	//TODO expose some transport parameters
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			MaxIdleConnsPerHost:   100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+	return httpClient
+}
+
+func multipartResponseToBlocks(lg *logger.SugarLogger, resp *http.Response) ([]*types.Block, error) {
+	mediaType, params, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse Content-Type header")
+	}
+	if mediaType != httputils.MultiPartFormData {
+		return nil, errors.Errorf("unexpected Content-Type: [%s], expected %s", mediaType, httputils.MultiPartFormData)
+	}
+	boundary, ok := params["boundary"]
+	if !ok {
+		return nil, errors.Errorf("%s boundary not found", httputils.MultiPartFormData)
+	}
+
+	mr := multipart.NewReader(resp.Body, boundary)
+	var blocks []*types.Block
+	var totalBytes int
+	for part, errP := mr.NextPart(); errP == nil; part, errP = mr.NextPart() {
+		lg.Debugf("reading part: %s, block: %s", part.FormName(), part.FileName())
+		blockBytes, err := ioutil.ReadAll(part)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to read block, part name: %s, file name: %s", part.FormName(), part.FileName())
+		}
+
+		block := &types.Block{}
+		if err := proto.Unmarshal(blockBytes, block); err != nil {
+			return nil, errors.Wrapf(err, "failed to unmarshal block, part name: %s, file name: %s", part.FormName(), part.FileName())
+		}
+		blocks = append(blocks, block)
+		totalBytes += len(blockBytes)
+	}
+
+	lg.Debugf("num blocks: %d, total-bytes: %d", len(blocks), totalBytes)
+	if len(blocks) == 0 {
+		return nil, errors.Errorf("empty %s, no blocks found", httputils.MultiPartFormData)
+	}
+
+	return blocks, nil
+}

--- a/internal/comm/catchup_client_test.go
+++ b/internal/comm/catchup_client_test.go
@@ -1,0 +1,378 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package comm_test
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/IBM-Blockchain/bcdb-server/config"
+	"github.com/IBM-Blockchain/bcdb-server/internal/comm"
+	"github.com/IBM-Blockchain/bcdb-server/internal/comm/mocks"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/logger"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCatchUpClient(t *testing.T) {
+	lg, err := logger.New(&logger.Config{
+		Level:         "debug",
+		OutputPath:    []string{"stdout"},
+		ErrOutputPath: []string{"stderr"},
+		Encoding:      "console",
+	})
+	require.NoError(t, err)
+
+	h := comm.NewCatchUpClient(lg)
+	require.NotNil(t, h)
+}
+
+func TestCatchUpClient_UpdateMembers(t *testing.T) {
+	lg, err := logger.New(&logger.Config{
+		Level:         "debug",
+		OutputPath:    []string{"stdout"},
+		ErrOutputPath: []string{"stderr"},
+		Encoding:      "console",
+	})
+	require.NoError(t, err)
+
+	h := comm.NewCatchUpClient(lg)
+	require.NotNil(t, h)
+
+	peer1 := &types.PeerConfig{
+		NodeId:   "node1",
+		RaftId:   1,
+		PeerHost: "127.0.0.1",
+		PeerPort: 9001,
+	}
+
+	peer2 := &types.PeerConfig{
+		NodeId:   "node2",
+		RaftId:   2,
+		PeerHost: "127.0.0.1",
+		PeerPort: 9002,
+	}
+	err = h.UpdateMembers([]*types.PeerConfig{peer1, peer2})
+	require.NoError(t, err)
+
+	peer2.PeerHost = "not a legal address"
+	err = h.UpdateMembers([]*types.PeerConfig{peer1, peer2})
+	require.EqualError(t, err, "failed to convert PeerConfig [node_id:\"node2\" raft_id:2 peer_host:\"not a legal address\" peer_port:9002 ] to url: parse \"http://not a legal address:9002\": invalid character \" \" in host name")
+}
+
+func TestCatchUpClient_GetHeight(t *testing.T) {
+	lg, err := logger.New(&logger.Config{
+		Level:         "debug",
+		OutputPath:    []string{"stdout"},
+		ErrOutputPath: []string{"stderr"},
+		Encoding:      "console",
+	})
+	require.NoError(t, err)
+
+	localConfigs, sharedConfig := newTestSetup(2)
+
+	tr1, err := startTransportWithLedger(t, lg, localConfigs, sharedConfig, 0, 5)
+	require.NoError(t, err)
+	defer tr1.Close()
+
+	cc := comm.NewCatchUpClient(lg)
+	require.NotNil(t, cc)
+	err = cc.UpdateMembers(sharedConfig.ConsensusConfig.Members)
+	require.NoError(t, err)
+
+	h, err := cc.GetHeight(context.Background(), 1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), h)
+}
+
+func TestCatchUpClient_GetBlocks(t *testing.T) {
+	lg, err := logger.New(&logger.Config{
+		Level:         "info",
+		OutputPath:    []string{"stdout"},
+		ErrOutputPath: []string{"stderr"},
+		Encoding:      "console",
+	})
+	require.NoError(t, err)
+
+	localConfigs, sharedConfig := newTestSetup(2)
+
+	tr1, err := startTransportWithLedger(t, lg, localConfigs, sharedConfig, 0, 5)
+	require.NoError(t, err)
+	defer tr1.Close()
+
+	cc := comm.NewCatchUpClient(lg)
+	require.NotNil(t, cc)
+	err = cc.UpdateMembers(sharedConfig.ConsensusConfig.Members)
+	require.NoError(t, err)
+
+	blocks, err := cc.GetBlocks(context.Background(), 1, 2, 4)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(blocks))
+
+	blocks, err = cc.GetBlocks(context.Background(), 2, 2, 4)
+	require.EqualError(t, err, "Get \"http://127.0.0.1:33001/bcdb-peer/blocks?end=4&start=2\": dial tcp 127.0.0.1:33001: connect: connection refused")
+
+	tr2, err := startTransportWithLedger(t, lg, localConfigs, sharedConfig, 1, 5)
+	require.NoError(t, err)
+	defer tr2.Close()
+
+	blocks, err = cc.GetBlocks(context.Background(), 2, 2, 4)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(blocks))
+}
+
+func TestCatchUpClient_PullBlocks(t *testing.T) {
+	lg, err := logger.New(&logger.Config{
+		Level:         "debug",
+		OutputPath:    []string{"stdout"},
+		ErrOutputPath: []string{"stderr"},
+		Encoding:      "console",
+	})
+	require.NoError(t, err)
+
+	localConfigs, sharedConfig := newTestSetup(3)
+
+	tr1, err := startTransportWithLedger(t, lg, localConfigs, sharedConfig, 0, 5)
+	require.NoError(t, err)
+	defer tr1.Close()
+
+	tr2, err := startTransportWithLedger(t, lg, localConfigs, sharedConfig, 1, 10)
+	require.NoError(t, err)
+	defer tr2.Close()
+
+	cc := comm.NewCatchUpClient(lg)
+	require.NotNil(t, cc)
+	err = cc.UpdateMembers(sharedConfig.ConsensusConfig.Members)
+	require.NoError(t, err)
+
+	//get all from the leader hint
+	blocks, err := cc.PullBlocks(context.Background(), 1, 3, 1)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(blocks))
+	//get some from the leader hint
+	blocks, err = cc.PullBlocks(context.Background(), 1, 8, 1)
+	require.NoError(t, err)
+	require.Equal(t, 5, len(blocks))
+	//get all from member 2, wrong leader hint
+	blocks, err = cc.PullBlocks(context.Background(), 6, 9, 1)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(blocks))
+	//get all from one of 1/2, no hint
+	blocks, err = cc.PullBlocks(context.Background(), 1, 3, 0)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(blocks))
+	//get all from member 2, no hint
+	blocks, err = cc.PullBlocks(context.Background(), 6, 9, 0)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(blocks))
+}
+
+func TestCatchUpClient_PullBlocksLoop(t *testing.T) {
+	lg, err := logger.New(&logger.Config{
+		Level:         "info",
+		OutputPath:    []string{"stdout"},
+		ErrOutputPath: []string{"stderr"},
+		Encoding:      "console",
+	})
+	require.NoError(t, err)
+
+	localConfigs, sharedConfig := newTestSetup(4)
+
+	tr1, err := startTransportWithLedger(t, lg, localConfigs, sharedConfig, 0, 50)
+	require.NoError(t, err)
+	defer tr1.Close()
+
+	tr2, err := startTransportWithLedger(t, lg, localConfigs, sharedConfig, 1, 100)
+	require.NoError(t, err)
+	defer tr2.Close()
+
+	tr3, err := startTransportWithLedger(t, lg, localConfigs, sharedConfig, 2, 150)
+	require.NoError(t, err)
+	defer tr3.Close()
+
+	cc := comm.NewCatchUpClient(lg)
+	require.NotNil(t, cc)
+	err = cc.UpdateMembers(sharedConfig.ConsensusConfig.Members)
+	require.NoError(t, err)
+
+	type testCase struct {
+		name string
+		hint uint64
+	}
+	testCases := []testCase{
+		{name: "wrong hint", hint: 1},
+		{name: "no hint", hint: 0},
+		{name: "good hint", hint: 3},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ledger4 := &memLedger{}
+
+			var num uint64
+			var target uint64 = 150
+			for num < target {
+				blocks, err := cc.PullBlocks(context.Background(), num+1, target, tc.hint)
+				require.NoError(t, err)
+				for _, block := range blocks {
+					err = ledger4.Append(block)
+					require.NoError(t, err)
+					num = block.Header.BaseHeader.Number
+				}
+			}
+
+			h, err := ledger4.Height()
+			require.NoError(t, err)
+			require.Equal(t, target, h)
+		})
+	}
+}
+
+func TestCatchUpClient_PullBlocksRetry(t *testing.T) {
+	dir, err := ioutil.TempDir("", "catchup")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	lg, err := logger.New(&logger.Config{
+		Level:         "debug",
+		OutputPath:    []string{"stdout", path.Join(dir, "test.log")},
+		ErrOutputPath: []string{"stderr"},
+		Encoding:      "console",
+	})
+	require.NoError(t, err)
+
+	mn := comm.RetryIntervalMin
+	mx := comm.RetryIntervalMax
+	comm.RetryIntervalMin = 100 * time.Microsecond
+	comm.RetryIntervalMax = time.Millisecond
+	defer func() {
+		comm.RetryIntervalMin = mn
+		comm.RetryIntervalMax = mx
+	}()
+
+	localConfigs, sharedConfig := newTestSetup(3)
+
+	tr1, err := startTransportWithLedger(t, lg, localConfigs, sharedConfig, 0, 50)
+	require.NoError(t, err)
+	defer tr1.Close()
+
+	cc := comm.NewCatchUpClient(lg)
+	require.NotNil(t, cc)
+	err = cc.UpdateMembers(sharedConfig.ConsensusConfig.Members)
+	require.NoError(t, err)
+
+	ledger4 := &memLedger{}
+
+	var num uint64
+	var target uint64 = 150
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	pullBlocksLoop := func() {
+		for num < target {
+			blocks, err := cc.PullBlocks(context.Background(), num+1, target, 0)
+			require.NoError(t, err)
+			for _, block := range blocks {
+				err = ledger4.Append(block)
+				require.NoError(t, err)
+				num = block.Header.BaseHeader.Number
+			}
+		}
+		wg.Done()
+	}
+
+	go pullBlocksLoop()
+
+	time.Sleep(10 * time.Millisecond)
+	tr2, err := startTransportWithLedger(t, lg, localConfigs, sharedConfig, 1, 100)
+	require.NoError(t, err)
+	defer tr2.Close()
+
+	time.Sleep(10 * time.Millisecond)
+	tr3, err := startTransportWithLedger(t, lg, localConfigs, sharedConfig, 2, 150)
+	require.NoError(t, err)
+	defer tr3.Close()
+
+	wg.Wait()
+
+	h, err := ledger4.Height()
+	require.NoError(t, err)
+	require.Equal(t, target, h)
+
+	logBytes, err := ioutil.ReadFile(path.Join(dir, "test.log"))
+	require.NoError(t, err)
+	require.Contains(t, string(logBytes), "Retry interval max reached")
+}
+
+func TestCatchUpClient_PullBlocksCancel(t *testing.T) {
+	lg, err := logger.New(&logger.Config{
+		Level:         "info",
+		OutputPath:    []string{"stdout"},
+		ErrOutputPath: []string{"stderr"},
+		Encoding:      "console",
+	})
+	require.NoError(t, err)
+
+	mn := comm.RetryIntervalMin
+	mx := comm.RetryIntervalMax
+	comm.RetryIntervalMin = 100 * time.Microsecond
+	comm.RetryIntervalMax = time.Millisecond
+	defer func() {
+		comm.RetryIntervalMin = mn
+		comm.RetryIntervalMax = mx
+	}()
+
+	localConfigs, sharedConfig := newTestSetup(3)
+
+	tr1, err := startTransportWithLedger(t, lg, localConfigs, sharedConfig, 0, 50)
+	require.NoError(t, err)
+	defer tr1.Close()
+
+	cc := comm.NewCatchUpClient(lg)
+	require.NotNil(t, cc)
+	err = cc.UpdateMembers(sharedConfig.ConsensusConfig.Members)
+	require.NoError(t, err)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		blocks, err := cc.PullBlocks(ctx, 51, 100, 0)
+		wg.Done()
+		assert.EqualError(t, err, "PullBlocks canceled: context canceled")
+		assert.Nil(t, blocks)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	wg.Wait()
+}
+
+func startTransportWithLedger(t *testing.T, lg *logger.SugarLogger, localConfigs []*config.LocalConfiguration, sharedConfig *types.ClusterConfig, index, height uint64) (*comm.HTTPTransport, error) {
+	ledger := &memLedger{}
+	for n := uint64(1); n <= height; n++ {
+		ledger.Append(&types.Block{Header: &types.BlockHeader{BaseHeader: &types.BlockHeaderBase{Number: n}}})
+	}
+	cl := &mocks.ConsensusListener{}
+	tr := comm.NewHTTPTransport(&comm.Config{
+		LocalConf:    localConfigs[index],
+		Logger:       lg,
+		LedgerReader: ledger,
+	})
+	require.NotNil(t, tr)
+	err := tr.SetConsensusListener(cl)
+	require.NoError(t, err)
+	err = tr.UpdateClusterConfig(sharedConfig)
+	require.NoError(t, err)
+
+	err = tr.Start()
+	require.NoError(t, err)
+	return tr, err
+}

--- a/internal/comm/catchup_handler_test.go
+++ b/internal/comm/catchup_handler_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/IBM-Blockchain/bcdb-server/internal/comm"
 	"github.com/IBM-Blockchain/bcdb-server/internal/comm/mocks"
+	"github.com/IBM-Blockchain/bcdb-server/internal/httputils"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/logger"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
 	"github.com/golang/protobuf/proto"
@@ -124,7 +125,7 @@ func TestCatchupHandler_ServeHTTP_Blocks(t *testing.T) {
 		q.Add("start", "0")
 		q.Add("end", "4")
 		req.URL.RawQuery = q.Encode()
-		req.Header.Set("Accept", "multipart/form-data")
+		req.Header.Set("Accept", httputils.MultiPartFormData)
 		t.Logf("url: %s", req.URL.String())
 
 		h.ServeHTTP(resp, req)
@@ -143,7 +144,7 @@ func TestCatchupHandler_ServeHTTP_Blocks(t *testing.T) {
 		q.Add("start", "10")
 		q.Add("end", "14")
 		req.URL.RawQuery = q.Encode()
-		req.Header.Set("Accept", "multipart/form-data")
+		req.Header.Set("Accept", httputils.MultiPartFormData)
 		t.Logf("url: %s", req.URL.String())
 
 		h.ServeHTTP(resp, req)
@@ -162,7 +163,7 @@ func TestCatchupHandler_ServeHTTP_Blocks(t *testing.T) {
 		q.Add("start", "4")
 		q.Add("end", "2")
 		req.URL.RawQuery = q.Encode()
-		req.Header.Set("Accept", "multipart/form-data")
+		req.Header.Set("Accept", httputils.MultiPartFormData)
 		t.Logf("url: %s", req.URL.String())
 
 		h.ServeHTTP(resp, req)
@@ -181,7 +182,7 @@ func TestCatchupHandler_ServeHTTP_Blocks(t *testing.T) {
 		q.Add("start", "2")
 		q.Add("end", "4")
 		req.URL.RawQuery = q.Encode()
-		req.Header.Set("Accept", "multipart/form-data")
+		req.Header.Set("Accept", httputils.MultiPartFormData)
 		t.Logf("url: %s", req.URL.String())
 
 		h.ServeHTTP(resp, req)
@@ -217,7 +218,7 @@ func TestCatchupHandler_ServeHTTP_Blocks(t *testing.T) {
 		q.Add("start", "2")
 		q.Add("end", "10")
 		req.URL.RawQuery = q.Encode()
-		req.Header.Set("Accept", "multipart/form-data")
+		req.Header.Set("Accept", httputils.MultiPartFormData)
 		t.Logf("url: %s", req.URL.String())
 
 		h.ServeHTTP(resp, req)

--- a/internal/httputils/utils.go
+++ b/internal/httputils/utils.go
@@ -12,6 +12,8 @@ import (
 	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
 )
 
+const MultiPartFormData = "multipart/form-data"
+
 // SendHTTPResponse writes HTTP response back including HTTP code number and encode payload
 func SendHTTPResponse(w http.ResponseWriter, code int, payload interface{}) {
 	response, _ := json.Marshal(payload)
@@ -101,3 +103,4 @@ func GetVersion(params map[string]string) (*types.Version, error) {
 		TxNum:    txNum,
 	}, nil
 }
+


### PR DESCRIPTION
The catchup client exposes methods that allow the block replicator to catch-up
with the cluster. It communicated with the catch-up service exposed by each peer.