### PR TITLE
Catchup at block replicator

### DIFF
--- a/internal/comm/catchup_client.go
+++ b/internal/comm/catchup_client.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/IBM-Blockchain/bcdb-server/internal/httputils"
 	"io/ioutil"
 	"math/rand"
 	"mime"
@@ -19,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/IBM-Blockchain/bcdb-server/internal/httputils"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/logger"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
 	"github.com/golang/protobuf/proto"

--- a/internal/comm/catchup_client_test.go
+++ b/internal/comm/catchup_client_test.go
@@ -5,7 +5,6 @@ package comm_test
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path"
@@ -289,12 +288,13 @@ func TestCatchUpClient_PullBlocksRetry(t *testing.T) {
 
 	go pullBlocksLoop()
 
-	time.Sleep(10 * time.Millisecond)
+	//TODO do "eventually" on `Retry interval max reached` instead, as this `Sleep` may creates a flake, see: https://github.com/IBM-Blockchain/bcdb-server/issues/188
+	time.Sleep(100 * time.Millisecond)
 	tr2, err := startTransportWithLedger(t, lg, localConfigs, sharedConfig, 1, 100)
 	require.NoError(t, err)
 	defer tr2.Close()
 
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	tr3, err := startTransportWithLedger(t, lg, localConfigs, sharedConfig, 2, 150)
 	require.NoError(t, err)
 	defer tr3.Close()
@@ -346,8 +346,8 @@ func TestCatchUpClient_PullBlocksCancel(t *testing.T) {
 	go func() {
 		blocks, err := cc.PullBlocks(ctx, 51, 100, 0)
 		wg.Done()
-		assert.EqualError(t, err, "PullBlocks canceled: context canceled")
-		assert.Nil(t, blocks)
+		require.EqualError(t, err, "PullBlocks canceled: context canceled")
+		require.Nil(t, blocks)
 	}()
 
 	time.Sleep(10 * time.Millisecond)

--- a/internal/comm/httptransport.go
+++ b/internal/comm/httptransport.go
@@ -197,6 +197,12 @@ func (p *HTTPTransport) SendConsensus(msgs []raftpb.Message) error {
 	return nil
 }
 
+// PullBlocks tries to pull as many blocks as possible from startBlock to endBlock (inclusive).
+//
+// The calling go-routine will block until some blocks are retrieved, depending on the availability of remote peers.
+// The underlying implementation will poll the cluster members, starting from the leader hint (if exists), until it can
+// retrieve some blocks. The call may return fewer blocks than requested. The `leaderID` is a hint to the leader's
+// Raft ID, and can be 0. The call maybe canceled using the context `ctx`.
 func (p *HTTPTransport) PullBlocks(ctx context.Context, startBlock, endBlock, leaderID uint64) ([]*types.Block, error) {
 	return p.catchUpClient.PullBlocks(ctx, startBlock, endBlock, leaderID)
 }

--- a/internal/httputils/utils.go
+++ b/internal/httputils/utils.go
@@ -1,5 +1,6 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 package httputils
 
 import (
@@ -10,9 +11,19 @@ import (
 	"strconv"
 
 	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+	"github.com/golang/protobuf/proto"
 )
 
 const MultiPartFormData = "multipart/form-data"
+
+func MarshalOrPanic(m proto.Message) []byte {
+	bytes, err := proto.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+
+	return bytes
+}
 
 // SendHTTPResponse writes HTTP response back including HTTP code number and encode payload
 func SendHTTPResponse(w http.ResponseWriter, code int, payload interface{}) {

--- a/internal/replication/blockreplicator.go
+++ b/internal/replication/blockreplicator.go
@@ -53,7 +53,9 @@ type BlockReplicator struct {
 	mutex           sync.Mutex
 	clusterConfig   *types.ClusterConfig
 	lastKnownLeader uint64
-	appliedIndex    uint64
+
+	appliedIndex uint64
+	lastBlock    *types.Block
 
 	// needed by snapshotting
 	sizeLimit        uint64 // SnapshotIntervalSize in bytes
@@ -126,18 +128,21 @@ func NewBlockReplicator(conf *Config) (*BlockReplicator, error) {
 		br.lg.Panic("Failed to read block height")
 	}
 
-	if height > 1 {
-		lastBlock, err := br.ledgerReader.Get(height)
+	if height > 0 {
+		br.lastBlock, err = br.ledgerReader.Get(height)
 		if err != nil {
 			br.lg.Panic("Failed to read last block")
 		}
-		br.appliedIndex = lastBlock.GetConsensusMetadata().GetRaftIndex()
-		br.lg.Debugf("last block [%d], consensus metadata: %+v",
-			lastBlock.GetHeader().GetBaseHeader().GetNumber(), lastBlock.GetConsensusMetadata())
 	}
 
-	//TODO DO NOT use Applied option in config, we need to guard against replay of written blocks with `appliedIndex` instead.
-	config := &raft.Config{
+	if height > 1 {
+		metadata := br.lastBlock.GetConsensusMetadata()
+		br.appliedIndex = metadata.GetRaftIndex()
+		br.lg.Debugf("last block [%d], consensus metadata: %+v", height, metadata)
+	}
+
+	//DO NOT use Applied option in config, we guard against replay of written blocks with `appliedIndex` instead.
+	raftConfig := &raft.Config{
 		ID:              raftID,
 		ElectionTick:    int(br.clusterConfig.ConsensusConfig.RaftConfig.ElectionTicks),
 		HeartbeatTick:   int(br.clusterConfig.ConsensusConfig.RaftConfig.HeartbeatTicks),
@@ -152,19 +157,19 @@ func NewBlockReplicator(conf *Config) (*BlockReplicator, error) {
 		DisableProposalForwarding: true, // This prevents blocks from being accidentally proposed by followers
 	}
 
-	lg.Debugf("haveWAL: %v, Storage: %v, Raft config: %+v", haveWAL, storage, config)
+	lg.Debugf("haveWAL: %v, Storage: %v, Raft config: %+v", haveWAL, storage, raftConfig)
 
 	joinExistingCluster := false // TODO support node join to an existing cluster
 
 	if haveWAL {
-		br.raftNode = raft.RestartNode(config)
+		br.raftNode = raft.RestartNode(raftConfig)
 	} else {
 		if joinExistingCluster {
 			// TODO support node join to an existing cluster
 			br.lg.Panicf("not supported yet: joinExistingCluster")
 		} else {
 			startPeers := raftPeers(br.clusterConfig)
-			br.raftNode = raft.StartNode(config, startPeers)
+			br.raftNode = raft.StartNode(raftConfig, startPeers)
 		}
 	}
 
@@ -213,6 +218,15 @@ func (br *BlockReplicator) runRaftEventLoop(readyCh chan<- struct{}) {
 	br.lg.Info("Starting the block replicator event loop")
 	close(readyCh)
 
+	//If height is smaller than the block number in the last snapshot, it means the node stopped after a
+	// snapshot trigger was received, but before catch-up was completed. In order to cover this case, we do
+	// catch-up first.
+	if lastSnapshot := br.raftStorage.Snapshot(); !raft.IsEmptySnap(lastSnapshot) {
+		if err := br.catchUp(lastSnapshot); err != nil {
+			br.lg.Panicf("Failed to catch-up to last snapshot: %+v", lastSnapshot)
+		}
+	}
+
 	// TODO use 'clock.Clock' so that tests can inject a fake clock
 	tickInterval, err := time.ParseDuration(br.clusterConfig.ConsensusConfig.RaftConfig.TickInterval)
 	if err != nil {
@@ -245,18 +259,7 @@ Event_Loop:
 				br.lg.Warningf("WAL sync took %v seconds and the network is configured to start elections after %v seconds. Your disk is too slow and may cause loss of quorum and trigger leadership election.", duration, electionTimeout)
 			}
 
-			if !raft.IsEmptySnap(rd.Snapshot) {
-				//TODO support snapshots
-				br.lg.Panicf("Snapshots not supported yet (loop): %+v", rd.Snapshot)
-			}
-
-			br.transport.SendConsensus(rd.Messages)
-
-			if ok := br.deliverEntries(rd.CommittedEntries); !ok {
-				br.lg.Warningf("Failed to deliver committed entries, breaking out of event loop")
-				break Event_Loop
-			}
-
+			// update last known leader
 			if rd.SoftState != nil {
 				leader := atomic.LoadUint64(&rd.SoftState.Lead) // etcdraft requires atomic access to this var
 				if leader != raft.None {
@@ -271,6 +274,19 @@ Event_Loop:
 					br.lastKnownLeader = leader
 				}
 				br.mutex.Unlock()
+			}
+
+			if !raft.IsEmptySnap(rd.Snapshot) {
+				if err := br.catchUp(rd.Snapshot); err != nil {
+					br.lg.Panicf("Failed to catch-up to snapshot: %+v", rd.Snapshot)
+				}
+			}
+
+			br.transport.SendConsensus(rd.Messages)
+
+			if ok := br.deliverEntries(rd.CommittedEntries); !ok {
+				br.lg.Warningf("Failed to deliver committed entries, breaking out of event loop")
+				break Event_Loop
 			}
 
 			br.raftNode.Advance()
@@ -288,6 +304,92 @@ Event_Loop:
 	}
 
 	br.lg.Info("Exiting block replicator event loop")
+}
+
+// When a node lags behind the cluster more than the last checkpoint of the leader, the leader will send a snapshot to
+// it. A snapshot is a block with some raft information. A received snapshot serves as a trigger for the node to
+// perform catch-up, or state transfer. It will contact one of the active members of the cluster (preferably the
+// leader), and will request the missing blocks up to the block indicated by the snapshot.
+func (br *BlockReplicator) catchUp(snap raftpb.Snapshot) error {
+	if snap.Metadata.Index <= br.appliedIndex {
+		br.lg.Debugf("Skip snapshot taken at index %d, because it is behind current applied index %d", snap.Metadata.Index, br.appliedIndex)
+		return nil
+	}
+
+	var snapBlock = &types.Block{}
+	if err := proto.Unmarshal(snap.Data, snapBlock); err != nil {
+		return errors.Errorf("failed to unmarshal snapshot data to block: %s", err)
+	}
+
+	br.lg.Debugf("last block: %+v", br.lastBlock)
+	br.lg.Debugf("snap block: %+v", snapBlock)
+	initBlockNumber := br.lastBlock.Header.BaseHeader.Number
+	if br.lastBlock.Header.BaseHeader.Number >= snapBlock.Header.BaseHeader.Number {
+		br.lg.Errorf("Snapshot is at block [%d], local block number is %d, no catch-up needed", snapBlock.Header.BaseHeader.Number, initBlockNumber)
+		return nil
+	}
+
+	br.lg.Infof("Starting state transfer; From block: %d, index %d; To block: %d, index: %d",
+		initBlockNumber, br.appliedIndex, snapBlock.Header.BaseHeader.Number, snap.Metadata.Index)
+	br.confState = snap.Metadata.ConfState
+	br.appliedIndex = snap.Metadata.Index
+
+	// Pull the missing blocks, starting with one past the last block we have, and ending with the block number from the snapshot.
+	for nextBlockNumber := initBlockNumber + 1; nextBlockNumber <= snapBlock.Header.BaseHeader.Number; {
+		var blocks []*types.Block
+		var err error
+		blocksReadyCh := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
+
+		//Try to pull some blocks in a go-routine so that we may cancel it if the server shuts down.
+		//Note that `PullBlocks` will not necessarily return all the blocks we requested, hence the enclosing loop.
+		go func() {
+			defer close(blocksReadyCh)
+			blocks, err = br.transport.PullBlocks(ctx, nextBlockNumber, snapBlock.Header.BaseHeader.Number, br.GetLeaderID())
+		}()
+
+		select {
+		case <-br.stopCh:
+			cancel()
+			<-blocksReadyCh
+			return &ierrors.ClosedError{ErrMsg: "server stopped during catch-up"}
+		case <-blocksReadyCh:
+			if err != nil {
+				switch err.(type) {
+				case *ierrors.ClosedError:
+					br.lg.Warnf("closing, stopping to pull blocks from cluster; last block number [%d], snapshot: %+v", br.lastBlock.Header.BaseHeader.Number, snap)
+					return nil
+				default:
+					return errors.Wrapf(err, "failed to pull blocks from cluster; last block number [%d], snapshot: %+v", br.lastBlock.Header.BaseHeader.Number, snap)
+				}
+			}
+
+			br.lg.Infof("Going to commit [%d] blocks", len(blocks)) //Not necessarily the entire range requested!
+
+			for _, blockToCommit := range blocks {
+				br.lg.Infof("enqueue for commit block [%d], ConsensusMetadata: [%+v]",
+					blockToCommit.GetHeader().GetBaseHeader().GetNumber(),
+					blockToCommit.GetConsensusMetadata())
+
+				if err := br.commitBlock(blockToCommit); err != nil {
+					switch err.(type) {
+					case *ierrors.ClosedError:
+						br.lg.Warnf("closing, stopping to pull blocks from cluster; last block number [%d], snapshot: %+v", br.lastBlock.Header.BaseHeader.Number, snap)
+						return nil
+					default:
+						return err
+					}
+				}
+
+				nextBlockNumber++
+			}
+		}
+	}
+
+	br.lg.Infof("Finished syncing with cluster up to and including block [%d]", br.lastBlock.Header.BaseHeader.Number)
+
+	return nil
+
 }
 
 func (br *BlockReplicator) deliverEntries(committedEntries []raftpb.Entry) bool {
@@ -330,19 +432,10 @@ func (br *BlockReplicator) deliverEntries(committedEntries []raftpb.Entry) bool 
 				RaftIndex: committedEntries[i].Index,
 			}
 
-			br.lg.Debugf("enqueue for commit block [%d] ", block.GetHeader().GetBaseHeader().GetNumber())
-			reConfig, err := br.oneQueueBarrier.EnqueueWait(block)
+			err := br.commitBlock(block)
 			if err != nil {
-				br.lg.Errorf("queue barrier error: %s, stopping block replicator", err.Error())
+				br.lg.Errorf("commit block error: %s, stopping block replicator", err.Error())
 				return false
-			}
-
-			if reConfig != nil {
-				clusterConfig := reConfig.(*types.ClusterConfig)
-				if err := br.updateClusterConfig(clusterConfig); err != nil {
-					// TODO support dynamic re-config
-					br.lg.Panicf("Failed to update to ClusterConfig during raft normal entry: error: %s", err)
-				}
 			}
 
 		case raftpb.EntryConfChange:
@@ -472,6 +565,31 @@ func (br *BlockReplicator) GetLeaderID() uint64 {
 	defer br.mutex.Unlock()
 
 	return br.lastKnownLeader
+}
+
+func (br *BlockReplicator) commitBlock(block *types.Block) error {
+	br.lg.Infof("enqueue for commit block [%d], ConsensusMetadata: %+v ",
+		block.GetHeader().GetBaseHeader().GetNumber(),
+		block.GetConsensusMetadata())
+
+	reConfig, err := br.oneQueueBarrier.EnqueueWait(block)
+	if err != nil {
+		return err
+	}
+
+	br.lastBlock = block
+
+	if reConfig == nil {
+		return nil
+	}
+
+	clusterConfig := reConfig.(*types.ClusterConfig)
+	if err := br.updateClusterConfig(clusterConfig); err != nil {
+		// TODO support dynamic re-config
+		br.lg.Panicf("Failed to update to ClusterConfig during raft normal entry: error: %s", err)
+	}
+
+	return nil
 }
 
 func (br *BlockReplicator) updateClusterConfig(clusterConfig *types.ClusterConfig) error {

--- a/internal/replication/blockreplicator_3node_test.go
+++ b/internal/replication/blockreplicator_3node_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/IBM-Blockchain/bcdb-server/internal/httputils"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +17,7 @@ import (
 // - Stop the leader, wait for new leader,
 // - Stop the leader, remaining node has no leader.
 func TestBlockReplicator_3Node_StartCloseStep(t *testing.T) {
-	env := createClusterEnv(t, "info", 3)
+	env := createClusterEnv(t, "info", 3, nil)
 	defer os.RemoveAll(env.testDir)
 	require.Equal(t, 3, len(env.nodes))
 
@@ -74,7 +75,7 @@ func TestBlockReplicator_3Node_StartCloseStep(t *testing.T) {
 // - Start 2nd node, wait for leader,
 // - Start 3rd, wait for consistent leader on all
 func TestBlockReplicator_3Node_StartStepClose(t *testing.T) {
-	env := createClusterEnv(t, "info", 3)
+	env := createClusterEnv(t, "info", 3, nil)
 	defer os.RemoveAll(env.testDir)
 	require.Equal(t, 3, len(env.nodes))
 
@@ -111,7 +112,7 @@ func TestBlockReplicator_3Node_StartStepClose(t *testing.T) {
 // - Stop a follower, wait for consistent leader on two,
 // - Restart the node, wait for consistent leader on all
 func TestBlockReplicator_3Node_Restart(t *testing.T) {
-	env := createClusterEnv(t, "info", 3)
+	env := createClusterEnv(t, "info", 3, nil)
 	defer os.RemoveAll(env.testDir)
 	require.Equal(t, 3, len(env.nodes))
 
@@ -177,7 +178,7 @@ func TestBlockReplicator_3Node_Restart(t *testing.T) {
 // - Start 3 nodes together, wait for leader,
 // - Submit 100 blocks, wait for all ledgers to get them.
 func TestBlockReplicator_3Node_Submit(t *testing.T) {
-	env := createClusterEnv(t, "info", 3)
+	env := createClusterEnv(t, "info", 3, nil)
 	defer os.RemoveAll(env.testDir)
 	require.Equal(t, 3, len(env.nodes))
 
@@ -227,7 +228,7 @@ func TestBlockReplicator_3Node_Submit(t *testing.T) {
 // - Stop a leader node,  wait for new leader, submit 100 blocks, wait for 2 ledgers to get them.
 // - Restart the node, wait for leader, wait for node to get missing blocks.
 func TestBlockReplicator_3Node_SubmitRecover(t *testing.T) {
-	env := createClusterEnv(t, "info", 3)
+	env := createClusterEnv(t, "info", 3, nil)
 	defer os.RemoveAll(env.testDir)
 	require.Equal(t, 3, len(env.nodes))
 
@@ -308,4 +309,100 @@ func TestBlockReplicator_3Node_SubmitRecover(t *testing.T) {
 		err := node.Close()
 		require.NoError(t, err)
 	}
+}
+
+// Scenario:
+// - Configure cluster to take snapshots every approx. 5 blocks.
+// - Start 3 nodes together, wait for leader, submit 10 blocks, wait for all ledgers to get them.
+// - Stop a follower node,  wait for leader, submit 10 blocks, wait for 2 ledgers to get them.
+// - Restart the node, wait for leader, wait for node to get missing blocks.
+//   Recovering node is expected to get a snapshot from the leader and trigger catch-up from it.
+// - Stop a leader node,  wait for new leader, submit 10 blocks, wait for 2 ledgers to get them.
+// - Restart the node, wait for leader, wait for node to get missing blocks.
+//   Recovering node is expected to get a snapshot from the leader and trigger catch-up from it.
+func TestBlockReplicator_3Node_Catchup(t *testing.T) {
+	block := &types.Block{
+		Header: &types.BlockHeader{
+			BaseHeader: &types.BlockHeaderBase{
+				Number:                1,
+				LastCommittedBlockNum: 1,
+			},
+		},
+		Payload: &types.Block_DataTxEnvelopes{},
+	}
+	raftConfig := proto.Clone(raftConfigNoSnapshots).(*types.RaftConfig)
+	raftConfig.SnapshotIntervalSize = uint64(4*len(httputils.MarshalOrPanic(block)) + 1) // snapshot every ~5 blocks
+
+	env := createClusterEnv(t, "info", 3, raftConfig)
+	defer os.RemoveAll(env.testDir)
+	require.Equal(t, 3, len(env.nodes))
+
+	for _, node := range env.nodes {
+		err := node.Start()
+		require.NoError(t, err)
+	}
+
+	// wait for a common leader
+	isLeaderCond := func() bool {
+		return env.ExistsAgreedLeader()
+	}
+	assert.Eventually(t, isLeaderCond, 10*time.Second, 100*time.Millisecond)
+
+	leaderIdx := env.FindLeaderIndex()
+	numBlocks := uint64(10)
+	for i := uint64(0); i < numBlocks; i++ {
+		b := proto.Clone(block).(*types.Block)
+		b.Header.BaseHeader.Number = 2 + i
+		err := env.nodes[leaderIdx].blockReplicator.Submit(b)
+		require.NoError(t, err)
+	}
+
+	// all get first 10
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(numBlocks + 1) }, 30*time.Second, 100*time.Millisecond)
+
+	// follower recovery
+	followerIdx1 := (leaderIdx + 1) % 3
+	followerIdx2 := (leaderIdx + 2) % 3
+
+	err := env.nodes[followerIdx1].Close()
+	require.NoError(t, err)
+	t.Logf("Stopped follower node, index: %d", followerIdx1)
+	for i := numBlocks; i < 2*numBlocks; i++ {
+		b := proto.Clone(block).(*types.Block)
+		b.Header.BaseHeader.Number = 2 + i
+		err := env.nodes[leaderIdx].blockReplicator.Submit(b)
+		require.NoError(t, err)
+	}
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(2*numBlocks+1, leaderIdx, followerIdx2) }, 30*time.Second, 100*time.Millisecond)
+
+	err = env.nodes[followerIdx1].Restart()
+	require.NoError(t, err)
+	t.Logf("Restarted follower node, index: %d", followerIdx1)
+	assert.Eventually(t, func() bool { return env.AssertEqualHeight(2*numBlocks + 1) }, 30*time.Second, 100*time.Millisecond)
+
+	// leader recovery
+	err = env.nodes[leaderIdx].Close()
+	require.NoError(t, err)
+	t.Logf("Stopped leader node, index: %d", leaderIdx)
+	assert.Eventually(t, func() bool { return env.ExistsAgreedLeader(followerIdx1, followerIdx2) }, 30*time.Second, 100*time.Millisecond)
+	newLeaderIdx := env.FindLeaderIndex()
+	for i := 2 * numBlocks; i < 3*numBlocks; i++ {
+		b := proto.Clone(block).(*types.Block)
+		b.Header.BaseHeader.Number = 2 + i
+		err := env.nodes[newLeaderIdx].blockReplicator.Submit(b)
+		require.NoError(t, err)
+	}
+	require.Eventually(t, func() bool { return env.AssertEqualHeight(3*numBlocks+1, followerIdx1, followerIdx2) }, 30*time.Second, 100*time.Millisecond)
+
+	err = env.nodes[leaderIdx].Restart()
+	require.NoError(t, err)
+	t.Logf("Restarted old leader node, index: %d", leaderIdx)
+	assert.Eventually(t, func() bool { return env.AssertEqualHeight(3*numBlocks + 1) }, 30*time.Second, 100*time.Millisecond)
+
+	for _, node := range env.nodes {
+		err := node.Close()
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, env.AssertEqualLedger())
 }


### PR DESCRIPTION
 Perform catch-up at block replicator
    
When a node lags behind the cluster more than the last checkpoint of the leader, the leader will send a snapshot to it. A snapshot is a block with some raft information. A received snapshot serves as a trigger for the node to perform catch-up, or state transfer.
It will contact one of the active members of the cluster (preferably the leader), and will request the missing blocks up to the block indicated by the snapshot.
