### PR TITLE
Refactor http utilities to common package

### DIFF
--- a/internal/httphandler/config_request_handler_test.go
+++ b/internal/httphandler/config_request_handler_test.go
@@ -13,10 +13,9 @@ import (
 	"testing"
 	"time"
 
-	interrors "github.com/IBM-Blockchain/bcdb-server/internal/errors"
-
 	"github.com/IBM-Blockchain/bcdb-server/internal/bcdb"
 	"github.com/IBM-Blockchain/bcdb-server/internal/bcdb/mocks"
+	interrors "github.com/IBM-Blockchain/bcdb-server/internal/errors"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/constants"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/logger"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/server/testutils"

--- a/internal/httphandler/db_request_handler_test.go
+++ b/internal/httphandler/db_request_handler_test.go
@@ -12,10 +12,9 @@ import (
 	"testing"
 	"time"
 
-	interrors "github.com/IBM-Blockchain/bcdb-server/internal/errors"
-
 	"github.com/IBM-Blockchain/bcdb-server/internal/bcdb"
 	"github.com/IBM-Blockchain/bcdb-server/internal/bcdb/mocks"
+	interrors "github.com/IBM-Blockchain/bcdb-server/internal/errors"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/constants"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/server/testutils"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/types"

--- a/internal/httphandler/ledger_request_handler.go
+++ b/internal/httphandler/ledger_request_handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/IBM-Blockchain/bcdb-server/internal/bcdb"
 	"github.com/IBM-Blockchain/bcdb-server/internal/errors"
+	"github.com/IBM-Blockchain/bcdb-server/internal/httputils"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/constants"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/cryptoservice"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/logger"
@@ -85,7 +86,7 @@ func (p *ledgerRequestHandler) blockQuery(response http.ResponseWriter, request 
 			status = http.StatusInternalServerError
 		}
 
-		SendHTTPResponse(
+		httputils.SendHTTPResponse(
 			response,
 			status,
 			&types.HttpResponseErr{
@@ -94,7 +95,7 @@ func (p *ledgerRequestHandler) blockQuery(response http.ResponseWriter, request 
 		return
 	}
 
-	SendHTTPResponse(response, http.StatusOK, data)
+	httputils.SendHTTPResponse(response, http.StatusOK, data)
 }
 
 func (p *ledgerRequestHandler) pathQuery(response http.ResponseWriter, request *http.Request) {
@@ -117,7 +118,7 @@ func (p *ledgerRequestHandler) pathQuery(response http.ResponseWriter, request *
 			status = http.StatusInternalServerError
 		}
 
-		SendHTTPResponse(
+		httputils.SendHTTPResponse(
 			response,
 			status,
 			&types.HttpResponseErr{
@@ -126,7 +127,7 @@ func (p *ledgerRequestHandler) pathQuery(response http.ResponseWriter, request *
 		return
 	}
 
-	SendHTTPResponse(response, http.StatusOK, data)
+	httputils.SendHTTPResponse(response, http.StatusOK, data)
 }
 
 func (p *ledgerRequestHandler) txProof(response http.ResponseWriter, request *http.Request) {
@@ -149,7 +150,7 @@ func (p *ledgerRequestHandler) txProof(response http.ResponseWriter, request *ht
 			status = http.StatusInternalServerError
 		}
 
-		SendHTTPResponse(
+		httputils.SendHTTPResponse(
 			response,
 			status,
 			&types.HttpResponseErr{
@@ -158,7 +159,7 @@ func (p *ledgerRequestHandler) txProof(response http.ResponseWriter, request *ht
 		return
 	}
 
-	SendHTTPResponse(response, http.StatusOK, data)
+	httputils.SendHTTPResponse(response, http.StatusOK, data)
 }
 
 func (p *ledgerRequestHandler) dataProof(response http.ResponseWriter, request *http.Request) {
@@ -180,7 +181,7 @@ func (p *ledgerRequestHandler) dataProof(response http.ResponseWriter, request *
 			status = http.StatusInternalServerError
 		}
 
-		SendHTTPResponse(
+		httputils.SendHTTPResponse(
 			response,
 			status,
 			&types.HttpResponseErr{
@@ -189,7 +190,7 @@ func (p *ledgerRequestHandler) dataProof(response http.ResponseWriter, request *
 		return
 	}
 
-	SendHTTPResponse(response, http.StatusOK, data)
+	httputils.SendHTTPResponse(response, http.StatusOK, data)
 }
 
 func (p *ledgerRequestHandler) txReceipt(response http.ResponseWriter, request *http.Request) {
@@ -212,7 +213,7 @@ func (p *ledgerRequestHandler) txReceipt(response http.ResponseWriter, request *
 			status = http.StatusInternalServerError
 		}
 
-		SendHTTPResponse(
+		httputils.SendHTTPResponse(
 			response,
 			status,
 			&types.HttpResponseErr{
@@ -221,26 +222,26 @@ func (p *ledgerRequestHandler) txReceipt(response http.ResponseWriter, request *
 		return
 	}
 
-	SendHTTPResponse(response, http.StatusOK, data)
+	httputils.SendHTTPResponse(response, http.StatusOK, data)
 }
 
 func (p *ledgerRequestHandler) invalidPathQuery(response http.ResponseWriter, request *http.Request) {
 	err := &types.HttpResponseErr{
 		ErrMsg: "query error - bad or missing start/end block number",
 	}
-	SendHTTPResponse(response, http.StatusBadRequest, err)
+	httputils.SendHTTPResponse(response, http.StatusBadRequest, err)
 }
 
 func (p *ledgerRequestHandler) invalidTxProof(response http.ResponseWriter, request *http.Request) {
 	err := &types.HttpResponseErr{
 		ErrMsg: "tx proof query error - bad or missing query parameter",
 	}
-	SendHTTPResponse(response, http.StatusBadRequest, err)
+	httputils.SendHTTPResponse(response, http.StatusBadRequest, err)
 }
 
 func (p *ledgerRequestHandler) invalidDataProof(response http.ResponseWriter, request *http.Request) {
 	err := &types.HttpResponseErr{
 		ErrMsg: "data proof query error - bad or missing query parameter",
 	}
-	SendHTTPResponse(response, http.StatusBadRequest, err)
+	httputils.SendHTTPResponse(response, http.StatusBadRequest, err)
 }

--- a/internal/httphandler/ledger_request_handler_test.go
+++ b/internal/httphandler/ledger_request_handler_test.go
@@ -611,7 +611,7 @@ func TestDataProofQuery(t *testing.T) {
 					BlockNumber: 2,
 					DbName:      "bdb",
 					Key:         "key1",
-					IsDeleted:     false,
+					IsDeleted:   false,
 				})
 				req.Header.Set(constants.SignatureHeader, base64.StdEncoding.EncodeToString(sig))
 				return req, nil
@@ -656,7 +656,7 @@ func TestDataProofQuery(t *testing.T) {
 					BlockNumber: 2,
 					DbName:      "bdb",
 					Key:         "key1",
-					IsDeleted:     true,
+					IsDeleted:   true,
 				})
 				req.Header.Set(constants.SignatureHeader, base64.StdEncoding.EncodeToString(sig))
 				return req, nil
@@ -683,7 +683,7 @@ func TestDataProofQuery(t *testing.T) {
 					BlockNumber: 2,
 					DbName:      "bdb",
 					Key:         "key1",
-					IsDeleted:     false,
+					IsDeleted:   false,
 				})
 				req.Header.Set(constants.SignatureHeader, base64.StdEncoding.EncodeToString(sig))
 				return req, nil
@@ -711,7 +711,7 @@ func TestDataProofQuery(t *testing.T) {
 					BlockNumber: 2,
 					DbName:      "bdb",
 					Key:         "key1",
-					IsDeleted:     false,
+					IsDeleted:   false,
 				})
 				req.Header.Set(constants.SignatureHeader, base64.StdEncoding.EncodeToString(sig))
 				return req, nil
@@ -739,7 +739,7 @@ func TestDataProofQuery(t *testing.T) {
 					BlockNumber: 2,
 					DbName:      "bdb",
 					Key:         "key1",
-					IsDeleted:     true,
+					IsDeleted:   true,
 				})
 				req.Header.Set(constants.SignatureHeader, base64.StdEncoding.EncodeToString(sig))
 				return req, nil

--- a/internal/httphandler/provenance_request_handler.go
+++ b/internal/httphandler/provenance_request_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/IBM-Blockchain/bcdb-server/internal/bcdb"
+	"github.com/IBM-Blockchain/bcdb-server/internal/httputils"
 	"github.com/IBM-Blockchain/bcdb-server/internal/worldstate"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/constants"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/cryptoservice"
@@ -96,7 +97,7 @@ func (p *provenanceRequestHandler) getHistoricalData(w http.ResponseWriter, r *h
 	case query.Direction == "next":
 		response, err = p.db.GetNextValues(query.DbName, query.Key, query.Version)
 	default:
-		SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{
+		httputils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{
 			ErrMsg: "direction must be either [previous] or [next]",
 		})
 	}
@@ -106,7 +107,7 @@ func (p *provenanceRequestHandler) getHistoricalData(w http.ResponseWriter, r *h
 		return
 	}
 
-	SendHTTPResponse(w, http.StatusOK, response)
+	httputils.SendHTTPResponse(w, http.StatusOK, response)
 }
 
 func (p *provenanceRequestHandler) getDataReaders(w http.ResponseWriter, r *http.Request) {
@@ -122,7 +123,7 @@ func (p *provenanceRequestHandler) getDataReaders(w http.ResponseWriter, r *http
 		return
 	}
 
-	SendHTTPResponse(w, http.StatusOK, response)
+	httputils.SendHTTPResponse(w, http.StatusOK, response)
 }
 
 func (p *provenanceRequestHandler) getDataWriters(w http.ResponseWriter, r *http.Request) {
@@ -138,7 +139,7 @@ func (p *provenanceRequestHandler) getDataWriters(w http.ResponseWriter, r *http
 		return
 	}
 
-	SendHTTPResponse(w, http.StatusOK, response)
+	httputils.SendHTTPResponse(w, http.StatusOK, response)
 }
 
 func (p *provenanceRequestHandler) getDataReadByUser(w http.ResponseWriter, r *http.Request) {
@@ -154,7 +155,7 @@ func (p *provenanceRequestHandler) getDataReadByUser(w http.ResponseWriter, r *h
 		return
 	}
 
-	SendHTTPResponse(w, http.StatusOK, response)
+	httputils.SendHTTPResponse(w, http.StatusOK, response)
 }
 
 func (p *provenanceRequestHandler) getDataWrittenByUser(w http.ResponseWriter, r *http.Request) {
@@ -170,7 +171,7 @@ func (p *provenanceRequestHandler) getDataWrittenByUser(w http.ResponseWriter, r
 		return
 	}
 
-	SendHTTPResponse(w, http.StatusOK, response)
+	httputils.SendHTTPResponse(w, http.StatusOK, response)
 }
 
 func (p *provenanceRequestHandler) getDataDeletedByUser(w http.ResponseWriter, r *http.Request) {
@@ -186,7 +187,7 @@ func (p *provenanceRequestHandler) getDataDeletedByUser(w http.ResponseWriter, r
 		return
 	}
 
-	SendHTTPResponse(w, http.StatusOK, response)
+	httputils.SendHTTPResponse(w, http.StatusOK, response)
 }
 
 func (p *provenanceRequestHandler) getTxIDsSubmittedBy(w http.ResponseWriter, r *http.Request) {
@@ -202,11 +203,11 @@ func (p *provenanceRequestHandler) getTxIDsSubmittedBy(w http.ResponseWriter, r 
 		return
 	}
 
-	SendHTTPResponse(w, http.StatusOK, response)
+	httputils.SendHTTPResponse(w, http.StatusOK, response)
 }
 
 func processInternalError(w http.ResponseWriter, r *http.Request, err error) {
-	SendHTTPResponse(
+	httputils.SendHTTPResponse(
 		w,
 		http.StatusInternalServerError,
 		&types.HttpResponseErr{
@@ -235,5 +236,5 @@ func (p *provenanceRequestHandler) getMostRecentUserOrNode(w http.ResponseWriter
 		return
 	}
 
-	SendHTTPResponse(w, http.StatusOK, response)
+	httputils.SendHTTPResponse(w, http.StatusOK, response)
 }

--- a/internal/httphandler/tx_handler.go
+++ b/internal/httphandler/tx_handler.go
@@ -1,0 +1,36 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package httphandler
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/IBM-Blockchain/bcdb-server/internal/bcdb"
+	internalerror "github.com/IBM-Blockchain/bcdb-server/internal/errors"
+	"github.com/IBM-Blockchain/bcdb-server/internal/httputils"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+)
+
+type txHandler struct {
+	db bcdb.DB
+}
+
+// HandleTransaction handles transaction submission
+func (t *txHandler) handleTransaction(w http.ResponseWriter, tx interface{}, timeout time.Duration) {
+	// If timeout == 0, tx is async, otherwise it is synchronous.
+	resp, err := t.db.SubmitTransaction(tx, timeout)
+	if err != nil {
+		switch err.(type) {
+		case *internalerror.DuplicateTxIDError:
+			httputils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
+		case *internalerror.TimeoutErr:
+			httputils.SendHTTPResponse(w, http.StatusAccepted, &types.HttpResponseErr{ErrMsg: "Transaction processing timeout"})
+		default:
+			httputils.SendHTTPResponse(w, http.StatusInternalServerError, &types.HttpResponseErr{ErrMsg: err.Error()})
+		}
+		return
+	}
+	httputils.SendHTTPResponse(w, http.StatusOK, resp)
+}

--- a/internal/httphandler/users_request_handler.go
+++ b/internal/httphandler/users_request_handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/IBM-Blockchain/bcdb-server/internal/bcdb"
 	"github.com/IBM-Blockchain/bcdb-server/internal/errors"
+	"github.com/IBM-Blockchain/bcdb-server/internal/httputils"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/constants"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/cryptoservice"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/logger"
@@ -68,7 +69,7 @@ func (u *usersRequestHandler) getUser(response http.ResponseWriter, request *htt
 			status = http.StatusInternalServerError
 		}
 
-		SendHTTPResponse(
+		httputils.SendHTTPResponse(
 			response,
 			status,
 			&types.HttpResponseErr{"error while processing '" + request.Method + " " + request.URL.String() + "' because " + err.Error()},
@@ -77,13 +78,13 @@ func (u *usersRequestHandler) getUser(response http.ResponseWriter, request *htt
 		return
 	}
 
-	SendHTTPResponse(response, http.StatusOK, user)
+	httputils.SendHTTPResponse(response, http.StatusOK, user)
 }
 
 func (u *usersRequestHandler) userTransaction(response http.ResponseWriter, request *http.Request) {
 	timeout, err := validateAndParseTxPostHeader(&request.Header)
 	if err != nil {
-		SendHTTPResponse(response, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
+		httputils.SendHTTPResponse(response, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
 		return
 	}
 
@@ -93,33 +94,33 @@ func (u *usersRequestHandler) userTransaction(response http.ResponseWriter, requ
 	txEnv := &types.UserAdministrationTxEnvelope{}
 	if err := d.Decode(txEnv); err != nil {
 		u.logger.Errorf(err.Error())
-		SendHTTPResponse(response, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
+		httputils.SendHTTPResponse(response, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
 		return
 	}
 
 	if txEnv.Payload == nil {
 		u.logger.Errorf(fmt.Sprintf("missing transaction envelope payload (%T)", txEnv.Payload))
-		SendHTTPResponse(response, http.StatusBadRequest,
+		httputils.SendHTTPResponse(response, http.StatusBadRequest,
 			&types.HttpResponseErr{ErrMsg: fmt.Sprintf("missing transaction envelope payload (%T)", txEnv.Payload)})
 		return
 	}
 
 	if txEnv.Payload.UserId == "" {
 		u.logger.Errorf(fmt.Sprintf("missing UserID in transaction envelope payload (%T)", txEnv.Payload))
-		SendHTTPResponse(response, http.StatusBadRequest,
+		httputils.SendHTTPResponse(response, http.StatusBadRequest,
 			&types.HttpResponseErr{ErrMsg: fmt.Sprintf("missing UserID in transaction envelope payload (%T)", txEnv.Payload)})
 		return
 	}
 
 	if len(txEnv.Signature) == 0 {
 		u.logger.Errorf(fmt.Sprintf("missing Signature in transaction envelope payload (%T)", txEnv.Payload))
-		SendHTTPResponse(response, http.StatusBadRequest,
+		httputils.SendHTTPResponse(response, http.StatusBadRequest,
 			&types.HttpResponseErr{ErrMsg: fmt.Sprintf("missing Signature in transaction envelope payload (%T)", txEnv.Payload)})
 		return
 	}
 
 	if err, code := VerifyRequestSignature(u.sigVerifier, txEnv.Payload.UserId, txEnv.Signature, txEnv.Payload); err != nil {
-		SendHTTPResponse(response, code, &types.HttpResponseErr{ErrMsg: err.Error()})
+		httputils.SendHTTPResponse(response, code, &types.HttpResponseErr{ErrMsg: err.Error()})
 		return
 	}
 

--- a/internal/httphandler/users_request_handler_test.go
+++ b/internal/httphandler/users_request_handler_test.go
@@ -12,10 +12,9 @@ import (
 	"testing"
 	"time"
 
-	interrors "github.com/IBM-Blockchain/bcdb-server/internal/errors"
-
 	"github.com/IBM-Blockchain/bcdb-server/internal/bcdb"
 	"github.com/IBM-Blockchain/bcdb-server/internal/bcdb/mocks"
+	interrors "github.com/IBM-Blockchain/bcdb-server/internal/errors"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/constants"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/server/testutils"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/types"

--- a/internal/httphandler/utils.go
+++ b/internal/httphandler/utils.go
@@ -1,71 +1,27 @@
 // Copyright IBM Corp. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 package httphandler
 
 import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"time"
 
-	internalerror "github.com/IBM-Blockchain/bcdb-server/internal/errors"
-
-	"github.com/IBM-Blockchain/bcdb-server/internal/bcdb"
+	"github.com/IBM-Blockchain/bcdb-server/internal/httputils"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/constants"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/cryptoservice"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
 	"github.com/gorilla/mux"
 )
 
-func MarshalOrPanic(response interface{}) []byte {
-	bytes, err := json.Marshal(response)
-	if err != nil {
-		panic(err)
-	}
-
-	return bytes
-}
-
-// SendHTTPResponse writes HTTP response back including HTTP code number and encode payload
-func SendHTTPResponse(w http.ResponseWriter, code int, payload interface{}) {
-	response, _ := json.Marshal(payload)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(code)
-	if _, err := w.Write(response); err != nil {
-		log.Printf("Warning: failed to write response [%v] to the response writer\n", w)
-	}
-}
-
-type txHandler struct {
-	db bcdb.DB
-}
-
-// HandleTransaction handles transaction submission
-func (t *txHandler) handleTransaction(w http.ResponseWriter, tx interface{}, timeout time.Duration) {
-	// If timeout == 0, tx is async, otherwise it is synchronous.
-	resp, err := t.db.SubmitTransaction(tx, timeout)
-	if err != nil {
-		switch err.(type) {
-		case *internalerror.DuplicateTxIDError:
-			SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
-		case *internalerror.TimeoutErr:
-			SendHTTPResponse(w, http.StatusAccepted, &types.HttpResponseErr{ErrMsg: "Transaction processing timeout"})
-		default:
-			SendHTTPResponse(w, http.StatusInternalServerError, &types.HttpResponseErr{ErrMsg: err.Error()})
-		}
-		return
-	}
-	SendHTTPResponse(w, http.StatusOK, resp)
-}
-
 func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryType string, signVerifier *cryptoservice.SignatureVerifier) (interface{}, bool) {
 	querierUserID, signature, err := validateAndParseHeader(&r.Header)
 	if err != nil {
-		SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
+		httputils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{ErrMsg: err.Error()})
 		return nil, true
 	}
 
@@ -99,9 +55,9 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 			NodeId: params["nodeId"],
 		}
 	case constants.GetBlockHeader:
-		blockNum, err := getUintParam("blockId", params)
+		blockNum, err := httputils.GetUintParam("blockId", params)
 		if err != nil {
-			SendHTTPResponse(w, http.StatusBadRequest, err)
+			httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
 			return nil, true
 		}
 
@@ -110,9 +66,9 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 			BlockNumber: blockNum,
 		}
 	case constants.GetPath:
-		startBlockNum, endBlockNum, err := getStartAndEndBlockNum(params)
+		startBlockNum, endBlockNum, err := httputils.GetStartAndEndBlockNum(params)
 		if err != nil {
-			SendHTTPResponse(w, http.StatusBadRequest, err)
+			httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
 			return nil, true
 		}
 
@@ -122,9 +78,9 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 			EndBlockNumber:   endBlockNum,
 		}
 	case constants.GetTxProof:
-		blockNum, txIndex, err := getBlockNumAndTxIndex(params)
+		blockNum, txIndex, err := httputils.GetBlockNumAndTxIndex(params)
 		if err != nil {
-			SendHTTPResponse(w, http.StatusBadRequest, err)
+			httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
 			return nil, true
 		}
 
@@ -134,9 +90,9 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 			TxIndex:     txIndex,
 		}
 	case constants.GetDataProof:
-		blockNum, err := getBlockNum(params)
+		blockNum, err := httputils.GetBlockNum(params)
 		if err != nil {
-			SendHTTPResponse(w, http.StatusBadRequest, err)
+			httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
 			return nil, true
 		}
 
@@ -144,7 +100,7 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 		if _, ok := params["deleted"]; ok {
 			deleted, err = strconv.ParseBool(params["deleted"])
 			if err != nil {
-				SendHTTPResponse(w, http.StatusBadRequest, err)
+				httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
 				return nil, true
 			}
 		}
@@ -162,15 +118,15 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 			TxId:   params["txId"],
 		}
 	case constants.GetHistoricalData:
-		version, err := getVersion(params)
+		version, err := httputils.GetVersion(params)
 		if err != nil {
-			SendHTTPResponse(w, http.StatusBadRequest, err)
+			httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
 			return nil, true
 		}
 
 		v, isOnlyDeletesSet := params["onlydeletes"]
 		if isOnlyDeletesSet && v != "true" {
-			SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{
+			httputils.SendHTTPResponse(w, http.StatusBadRequest, &types.HttpResponseErr{
 				ErrMsg: "the onlydeletes parameters must be set only to 'true'",
 			})
 			return nil, true
@@ -220,9 +176,9 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 			TargetUserId: params["userId"],
 		}
 	case constants.GetMostRecentUserOrNode:
-		version, err := getVersion(params)
+		version, err := httputils.GetVersion(params)
 		if err != nil {
-			SendHTTPResponse(w, http.StatusBadRequest, err)
+			httputils.SendHTTPResponse(w, http.StatusBadRequest, err)
 			return nil, true
 		}
 
@@ -243,7 +199,7 @@ func extractVerifiedQueryPayload(w http.ResponseWriter, r *http.Request, queryTy
 
 	err, status := VerifyRequestSignature(signVerifier, querierUserID, signature, payload)
 	if err != nil {
-		SendHTTPResponse(w, status, err)
+		httputils.SendHTTPResponse(w, status, err)
 		return nil, true
 	}
 
@@ -304,82 +260,3 @@ func validateAndParseTxPostHeader(h *http.Header) (time.Duration, error) {
 	return timeout, nil
 }
 
-func getBlockNumAndTxIndex(params map[string]string) (uint64, uint64, error) {
-	blockNum, err := getUintParam("blockId", params)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	txIndex, err := getUintParam("idx", params)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	return blockNum, txIndex, nil
-}
-
-func getBlockNum(params map[string]string) (uint64, error) {
-	blockNum, err := getUintParam("blockId", params)
-	if err != nil {
-		return 0, err
-	}
-
-	return blockNum, nil
-}
-
-func getStartAndEndBlockNum(params map[string]string) (uint64, uint64, error) {
-	startBlockNum, err := getUintParam("startId", params)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	endBlockNum, err := getUintParam("endId", params)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	if endBlockNum < startBlockNum {
-		return 0, 0, &types.HttpResponseErr{
-			ErrMsg: fmt.Sprintf("query error: startId=%d > endId=%d", startBlockNum, endBlockNum),
-		}
-	}
-
-	return startBlockNum, endBlockNum, nil
-}
-
-func getVersion(params map[string]string) (*types.Version, error) {
-	if _, ok := params["blknum"]; !ok {
-		return nil, nil
-	}
-
-	blockNum, err := getUintParam("blknum", params)
-	if err != nil {
-		return nil, err
-	}
-
-	txNum, err := getUintParam("txnum", params)
-	if err != nil {
-		return nil, err
-	}
-
-	return &types.Version{
-		BlockNum: blockNum,
-		TxNum:    txNum,
-	}, nil
-}
-
-func getUintParam(key string, params map[string]string) (uint64, *types.HttpResponseErr) {
-	valStr, ok := params[key]
-	if !ok {
-		return 0, &types.HttpResponseErr{
-			ErrMsg: "query error - bad or missing literal: " + key,
-		}
-	}
-	val, err := strconv.ParseUint(valStr, 10, 64)
-	if err != nil {
-		return 0, &types.HttpResponseErr{
-			ErrMsg: "query error - bad or missing literal: " + key + " " + err.Error(),
-		}
-	}
-	return val, nil
-}

--- a/internal/httphandler/utils_test.go
+++ b/internal/httphandler/utils_test.go
@@ -3,60 +3,17 @@
 package httphandler
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
-
-	"github.com/IBM-Blockchain/bcdb-server/pkg/logger"
 
 	"github.com/IBM-Blockchain/bcdb-server/internal/bcdb/mocks"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/cryptoservice"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/logger"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/server/testutils"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
 )
-
-func TestSendHTTPResponse(t *testing.T) {
-	t.Parallel()
-
-	t.Run("ok status", func(t *testing.T) {
-		t.Parallel()
-
-		w := httptest.NewRecorder()
-		dbStatus := &types.GetDBStatusResponseEnvelope{
-			Response: &types.GetDBStatusResponse{
-				Header: &types.ResponseHeader{
-					NodeId: "testID",
-				},
-				Exist: false,
-			},
-		}
-		SendHTTPResponse(w, http.StatusOK, dbStatus)
-
-		require.Equal(t, http.StatusOK, w.Code)
-		actualDBStatus := &types.GetDBStatusResponseEnvelope{}
-		require.NoError(t, json.Unmarshal(w.Body.Bytes(), actualDBStatus))
-		require.True(t, proto.Equal(dbStatus, actualDBStatus))
-	})
-
-	t.Run("forbidden status", func(t *testing.T) {
-		t.Parallel()
-
-		w := httptest.NewRecorder()
-		err := &types.HttpResponseErr{
-			ErrMsg: "user does not have a read permission",
-		}
-		SendHTTPResponse(w, http.StatusForbidden, err)
-
-		require.Equal(t, http.StatusForbidden, w.Code)
-		actualErr := &types.HttpResponseErr{}
-		require.NoError(t, json.Unmarshal(w.Body.Bytes(), actualErr))
-		require.Equal(t, err, actualErr)
-	})
-}
 
 func TestVerifyRequestSignature(t *testing.T) {
 	lg, err := logger.New(&logger.Config{

--- a/internal/httputils/utils.go
+++ b/internal/httputils/utils.go
@@ -1,0 +1,103 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package httputils
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+)
+
+// SendHTTPResponse writes HTTP response back including HTTP code number and encode payload
+func SendHTTPResponse(w http.ResponseWriter, code int, payload interface{}) {
+	response, _ := json.Marshal(payload)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if _, err := w.Write(response); err != nil {
+		log.Printf("Warning: failed to write response [%v] to the response writer\n", w)
+	}
+}
+
+func GetStartAndEndBlockNum(params map[string]string) (uint64, uint64, error) {
+	startBlockNum, err := GetUintParam("startId", params)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	endBlockNum, err := GetUintParam("endId", params)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if endBlockNum < startBlockNum {
+		return 0, 0, &types.HttpResponseErr{
+			ErrMsg: fmt.Sprintf("query error: startId=%d > endId=%d", startBlockNum, endBlockNum),
+		}
+	}
+
+	return startBlockNum, endBlockNum, nil
+}
+
+func GetUintParam(key string, params map[string]string) (uint64, *types.HttpResponseErr) {
+	valStr, ok := params[key]
+	if !ok {
+		return 0, &types.HttpResponseErr{
+			ErrMsg: "query error - bad or missing literal: " + key,
+		}
+	}
+	val, err := strconv.ParseUint(valStr, 10, 64)
+	if err != nil {
+		return 0, &types.HttpResponseErr{
+			ErrMsg: "query error - bad or missing literal: " + key + " " + err.Error(),
+		}
+	}
+	return val, nil
+}
+
+func GetBlockNumAndTxIndex(params map[string]string) (uint64, uint64, error) {
+	blockNum, err := GetUintParam("blockId", params)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	txIndex, err := GetUintParam("idx", params)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return blockNum, txIndex, nil
+}
+
+func GetBlockNum(params map[string]string) (uint64, error) {
+	blockNum, err := GetUintParam("blockId", params)
+	if err != nil {
+		return 0, err
+	}
+
+	return blockNum, nil
+}
+
+func GetVersion(params map[string]string) (*types.Version, error) {
+	if _, ok := params["blknum"]; !ok {
+		return nil, nil
+	}
+
+	blockNum, err := GetUintParam("blknum", params)
+	if err != nil {
+		return nil, err
+	}
+
+	txNum, err := GetUintParam("txnum", params)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.Version{
+		BlockNum: blockNum,
+		TxNum:    txNum,
+	}, nil
+}

--- a/internal/httputils/utils_test.go
+++ b/internal/httputils/utils_test.go
@@ -1,0 +1,53 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package httputils
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendHTTPResponse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok status", func(t *testing.T) {
+		t.Parallel()
+
+		w := httptest.NewRecorder()
+		dbStatus := &types.GetDBStatusResponseEnvelope{
+			Response: &types.GetDBStatusResponse{
+				Header: &types.ResponseHeader{
+					NodeId: "testID",
+				},
+				Exist: false,
+			},
+		}
+		SendHTTPResponse(w, http.StatusOK, dbStatus)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		actualDBStatus := &types.GetDBStatusResponseEnvelope{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), actualDBStatus))
+		require.True(t, proto.Equal(dbStatus, actualDBStatus))
+	})
+
+	t.Run("forbidden status", func(t *testing.T) {
+		t.Parallel()
+
+		w := httptest.NewRecorder()
+		err := &types.HttpResponseErr{
+			ErrMsg: "user does not have a read permission",
+		}
+		SendHTTPResponse(w, http.StatusForbidden, err)
+
+		require.Equal(t, http.StatusForbidden, w.Code)
+		actualErr := &types.HttpResponseErr{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), actualErr))
+		require.Equal(t, err, actualErr)
+	})
+}


### PR DESCRIPTION
Moving 3 functions from `httphandler/utils.go` to a leaf package in `httputils/utils.go`.
These functions will be used in the next commit, that introduces the http catch-up service in the comm package.

No functional change.

Signed-off-by: Yoav Tock <tock@il.ibm.com>