### PR TITLE
order preseving encoding for +ve and -ve numbers

### DIFF
--- a/internal/blockprocessor/committer_test.go
+++ b/internal/blockprocessor/committer_test.go
@@ -3,7 +3,6 @@
 package blockprocessor
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -366,10 +365,10 @@ func TestStateDBCommitterForDataBlockWithIndex(t *testing.T) {
 		},
 	}
 
-	encoded2015 := base64.StdEncoding.EncodeToString(stateindex.EncodeOrderPreservingVarUint64(2015))
-	encoded2016 := base64.StdEncoding.EncodeToString(stateindex.EncodeOrderPreservingVarUint64(2016))
-	encoded2018 := base64.StdEncoding.EncodeToString(stateindex.EncodeOrderPreservingVarUint64(2018))
-	encoded2021 := base64.StdEncoding.EncodeToString(stateindex.EncodeOrderPreservingVarUint64(2021))
+	encoded2015 := stateindex.EncodeOrderPreservingVarUint64(2015)
+	encoded2016 := stateindex.EncodeOrderPreservingVarUint64(2016)
+	encoded2018 := stateindex.EncodeOrderPreservingVarUint64(2018)
+	encoded2021 := stateindex.EncodeOrderPreservingVarUint64(2021)
 
 	expectedIndexBefore := []*worldstate.KVWithMetadata{
 		{

--- a/internal/stateindex/encoding.go
+++ b/internal/stateindex/encoding.go
@@ -1,13 +1,16 @@
 package stateindex
 
 import (
+	"errors"
 	"math"
 )
 
-// EncodeOrderPreservingVarUint64 returns a byte-representation for a uint64 number such that
+const hextable = "0123456789abcdef"
+
+// EncodeOrderPreservingVarUint64 returns a string-representation for a uint64 number such that
 // all zero-bits starting bytes are trimmed in order to reduce the length of the array
 // For preserving the order in a default bytes-comparison, first byte contains the number of remaining bytes.
-func EncodeOrderPreservingVarUint64(n uint64) []byte {
+func EncodeOrderPreservingVarUint64(n uint64) string {
 	var bytePosition int
 	for bytePosition = 0; bytePosition <= 7; bytePosition++ {
 		if byte(n>>(56-(bytePosition*8))) != 0x00 {
@@ -16,33 +19,51 @@ func EncodeOrderPreservingVarUint64(n uint64) []byte {
 	}
 
 	size := int8(8 - bytePosition)
-	encodedBytes := make([]byte, size+1)
-	encodedBytes[0] = byte(size)
-	p := 1
+	encodedBytes := make([]byte, encodedLen(int(size)+1))
+	b := byte(size)
+	// given that the size is <= 8, the 4 most significant bits would always be 0
+	encodedBytes[0] = '0'
+	encodedBytes[1] = hextable[b]
+
+	j := 2
 	for r := bytePosition; r <= 7; r++ {
-		encodedBytes[p] = byte(n >> (56 - (r * 8)))
-		p++
+		b = byte(n >> (56 - (r * 8)))
+		encodedBytes[j] = hextable[b>>4]
+		encodedBytes[j+1] = hextable[b&0x0f]
+		j += 2
 	}
-	return encodedBytes
+	return string(encodedBytes)
 }
 
-// decodeOrderPreservingVarUint64 decodes the number from the bytes obtained from method 'encodeOrderPreservingVarUint64'.
-// It returns the decoded number.
-func decodeOrderPreservingVarUint64(b []byte) uint64 {
-	size := int(b[0])
+// decodeOrderPreservingVarUint64 decodes the number from the string obtained from method 'EncodeOrderPreservingVarUint64'.
+// It returns the decoded number and error if any occurred during the decoding process.
+func decodeOrderPreservingVarUint64(s string) (uint64, error) {
+	bs := []byte(s)
+	sizeByte, err := convertHexAtLocationToBinary(bs, 0)
+	if err != nil {
+		return 0, err
+	}
+	size := int(sizeByte)
 	var v uint64
+
 	for i := 7; i >= 8-size; i-- {
-		v = v | uint64(b[size-(7-i)])<<(56-(i*8))
+		location := (size - (7 - i)) * 2 // 2 character per hex
+		b, err := convertHexAtLocationToBinary(bs, location)
+		if err != nil {
+			return 0, err
+		}
+		v = v | uint64(b)<<(56-(i*8))
 	}
-	return v
+
+	return v, nil
 }
 
-// EncodeReverseOrderVarUint64 returns a byte-representation for a uint64 number such that
+// EncodeReverseOrderVarUint64 returns a string-representation for a uint64 number such that
 // the number is first subtracted from MaxUint64 and then all the leading 0xff bytes
 // are trimmed and replaced by the number of such trimmed bytes. This helps in reducing the size.
-// In the byte order comparison this encoding ensures that encodeReverseOrderVarUint64(A) > encodeReverseOrderVarUint64(B),
+// In the byte order comparison this encoding ensures that EncodeReverseOrderVarUint64(A) > EncodeReverseOrderVarUint64(B),
 // If B > A
-func EncodeReverseOrderVarUint64(n uint64) []byte {
+func EncodeReverseOrderVarUint64(n uint64) string {
 	n = math.MaxUint64 - n
 
 	var bytePosition int
@@ -53,31 +74,76 @@ func EncodeReverseOrderVarUint64(n uint64) []byte {
 	}
 
 	size := int8(8 - bytePosition)
-	encodedBytes := make([]byte, size+1)
-	encodedBytes[0] = byte(bytePosition)
-	p := 1
+	encodedBytes := make([]byte, encodedLen(int(size)+1))
+	b := byte(bytePosition)
+	encodedBytes[0] = '0'
+	encodedBytes[1] = hextable[b]
+
+	j := 2
 	for r := bytePosition; r <= 7; r++ {
-		encodedBytes[p] = byte(n >> (56 - (r * 8)))
-		p++
+		b = byte(n >> (56 - (r * 8)))
+		encodedBytes[j] = hextable[b>>4]
+		encodedBytes[j+1] = hextable[b&0x0f]
+		j += 2
 	}
-	return encodedBytes
+	return string(encodedBytes)
 }
 
-// decodeReverseOrderVarUint64 decodes the number from the bytes obtained from function 'encodeReverseOrderVarUint64'.
-func decodeReverseOrderVarUint64(b []byte) uint64 {
-	bytePosition := int(b[0])
-
-	size := 8 - bytePosition
+// decodeReverseOrderVarUint64 decodes the number from the string obtained from function 'encodeReverseOrderVarUint64'.
+func decodeReverseOrderVarUint64(s string) (uint64, error) {
+	bs := []byte(s)
+	bytePosition, err := convertHexAtLocationToBinary(bs, 0)
+	if err != nil {
+		return 0, err
+	}
+	size := 8 - int(bytePosition)
 
 	var v uint64
 	var i int
 	for i = 7; i >= 8-size; i-- {
-		v = v | uint64(b[size-(7-i)])<<(56-(i*8))
+		location := (size - (7 - i)) * 2 // 2 character per hex
+		b, err := convertHexAtLocationToBinary(bs, location)
+		if err != nil {
+			return 0, err
+		}
+		v = v | uint64(b)<<(56-(i*8))
 	}
 
 	for j := i; j >= 0; j-- {
 		v = v | uint64(0xff)<<(56-(j*8))
 	}
 
-	return math.MaxUint64 - v
+	return math.MaxUint64 - v, nil
+}
+
+func convertHexAtLocationToBinary(b []byte, location int) (byte, error) {
+	firstChar, err := fromHexChar(b[location])
+	if err != nil {
+		return 0, err
+	}
+
+	secondChar, err := fromHexChar(b[location+1])
+	if err != nil {
+		return 0, err
+	}
+
+	return (firstChar << 4) | secondChar, nil
+}
+
+// EncodedLen returns the length of an encoding of n source bytes.
+// Specifically, it returns n * 2.
+func encodedLen(n int) int { return n * 2 }
+
+// fromHexChar converts a hex character into its value
+func fromHexChar(c byte) (byte, error) {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0', nil
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10, nil
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10, nil
+	default:
+		return 0, errors.New("invalid hex character [" + string(c) + "]")
+	}
 }

--- a/internal/stateindex/encoding_test.go
+++ b/internal/stateindex/encoding_test.go
@@ -1,9 +1,10 @@
 package stateindex
 
 import (
-	"bytes"
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestOrderPreservingEncodingDecoding(t *testing.T) {
@@ -16,11 +17,12 @@ func TestOrderPreservingEncodingDecoding(t *testing.T) {
 func testEncodeAndDecode(t *testing.T, n uint64) {
 	value := EncodeOrderPreservingVarUint64(n)
 	nextValue := EncodeOrderPreservingVarUint64(n + 1)
-	if !(bytes.Compare(value, nextValue) < 0) {
+	if !(value < nextValue) {
 		t.Fatalf("A smaller integer should result into smaller bytes. Encoded bytes for [%d] is [%x] and for [%d] is [%x]",
-			n, n+1, value, nextValue)
+			n, value, n+1, nextValue)
 	}
-	decodedValue := decodeOrderPreservingVarUint64(value)
+	decodedValue, err := decodeOrderPreservingVarUint64(value)
+	require.NoError(t, err)
 	if decodedValue != n {
 		t.Fatalf("Value not same after decoding. Original value = [%d], decode value = [%d]", n, decodedValue)
 	}
@@ -36,11 +38,12 @@ func TestReverseOrderPreservingEncodingDecoding(t *testing.T) {
 func testReverseOrderEncodingAndDecoding(t *testing.T, n uint64) {
 	value := EncodeReverseOrderVarUint64(n)
 	nextValue := EncodeReverseOrderVarUint64(n + 1)
-	if !(bytes.Compare(value, nextValue) > 0) {
+	if !(value > nextValue) {
 		t.Fatalf("A smaller integer should result into greater bytes. Encoded bytes for [%d] is [%x] and for [%d] is [%x]",
-			n, n+1, value, nextValue)
+			n, value, n+1, nextValue)
 	}
-	decodedValue := decodeReverseOrderVarUint64(value)
+	decodedValue, err := decodeReverseOrderVarUint64(value)
+	require.NoError(t, err)
 	if decodedValue != n {
 		t.Fatalf("Value not same after decoding. Original value = [%d], decode value = [%d]", n, decodedValue)
 	}


### PR DESCRIPTION
When we use order preserving encoded bytes of number in the
index entry, the json marshaler converts the bytes to base64
encoding which does not preserve the order.

This commit use hex encoding to convert a given number into
an order preserving string.

Signed-off-by: senthil <cendhu@gmail.com>