### PR TITLE
start index position enum (Beginning, Existing, Ending) from 1 instead of 0

### DIFF
--- a/internal/blockprocessor/committer_test.go
+++ b/internal/blockprocessor/committer_test.go
@@ -372,22 +372,22 @@ func TestStateDBCommitterForDataBlockWithIndex(t *testing.T) {
 
 	expectedIndexBefore := []*worldstate.KVWithMetadata{
 		{
-			Key: `{"a":"title","t":1,"m":"","vp":1,"v":"book1","kp":1,"k":"key1"}`,
+			Key: `{"a":"title","t":1,"m":"","vp":2,"v":"book1","kp":2,"k":"key1"}`,
 		},
 		{
-			Key: `{"a":"year","t":0,"m":"` + stateindex.PositiveNumber + `","vp":1,"v":"` + encoded2015 + `","kp":1,"k":"key1"}`,
+			Key: `{"a":"year","t":0,"m":"` + stateindex.PositiveNumber + `","vp":2,"v":"` + encoded2015 + `","kp":2,"k":"key1"}`,
 		},
 		{
-			Key: `{"a":"bestseller","t":2,"m":"","vp":1,"v":true,"kp":1,"k":"key1"}`,
+			Key: `{"a":"bestseller","t":2,"m":"","vp":2,"v":true,"kp":2,"k":"key1"}`,
 		},
 		{
-			Key: `{"a":"title","t":1,"m":"","vp":1,"v":"book2","kp":1,"k":"key2"}`,
+			Key: `{"a":"title","t":1,"m":"","vp":2,"v":"book2","kp":2,"k":"key2"}`,
 		},
 		{
-			Key: `{"a":"year","t":0,"m":"` + stateindex.PositiveNumber + `","vp":1,"v":"` + encoded2016 + `","kp":1,"k":"key2"}`,
+			Key: `{"a":"year","t":0,"m":"` + stateindex.PositiveNumber + `","vp":2,"v":"` + encoded2016 + `","kp":2,"k":"key2"}`,
 		},
 		{
-			Key: `{"a":"bestseller","t":2,"m":"","vp":1,"v":false,"kp":1,"k":"key2"}`,
+			Key: `{"a":"bestseller","t":2,"m":"","vp":2,"v":false,"kp":2,"k":"key2"}`,
 		},
 	}
 
@@ -541,22 +541,22 @@ func TestStateDBCommitterForDataBlockWithIndex(t *testing.T) {
 			},
 			expectedIndexAfter: []*worldstate.KVWithMetadata{
 				{
-					Key: `{"a":"title","t":1,"m":"","vp":1,"v":"book2","kp":1,"k":"key2"}`,
+					Key: `{"a":"title","t":1,"m":"","vp":2,"v":"book2","kp":2,"k":"key2"}`,
 				},
 				{
-					Key: `{"a":"year","t":0,"m":"` + stateindex.PositiveNumber + `","vp":1,"v":"` + encoded2018 + `","kp":1,"k":"key2"}`,
+					Key: `{"a":"year","t":0,"m":"` + stateindex.PositiveNumber + `","vp":2,"v":"` + encoded2018 + `","kp":2,"k":"key2"}`,
 				},
 				{
-					Key: `{"a":"bestseller","t":2,"m":"","vp":1,"v":true,"kp":1,"k":"key2"}`,
+					Key: `{"a":"bestseller","t":2,"m":"","vp":2,"v":true,"kp":2,"k":"key2"}`,
 				},
 				{
-					Key: `{"a":"title","t":1,"m":"","vp":1,"v":"book3","kp":1,"k":"key3"}`,
+					Key: `{"a":"title","t":1,"m":"","vp":2,"v":"book3","kp":2,"k":"key3"}`,
 				},
 				{
-					Key: `{"a":"year","t":0,"m":"` + stateindex.PositiveNumber + `","vp":1,"v":"` + encoded2021 + `","kp":1,"k":"key3"}`,
+					Key: `{"a":"year","t":0,"m":"` + stateindex.PositiveNumber + `","vp":2,"v":"` + encoded2021 + `","kp":2,"k":"key3"}`,
 				},
 				{
-					Key: `{"a":"bestseller","t":2,"m":"","vp":1,"v":false,"kp":1,"k":"key3"}`,
+					Key: `{"a":"bestseller","t":2,"m":"","vp":2,"v":false,"kp":2,"k":"key3"}`,
 				},
 			},
 		},

--- a/internal/stateindex/index_entries.go
+++ b/internal/stateindex/index_entries.go
@@ -24,7 +24,7 @@ const (
 )
 
 const (
-	Beginning = iota
+	Beginning = iota + 1
 	Existing
 	Ending
 )

--- a/internal/stateindex/index_entries_test.go
+++ b/internal/stateindex/index_entries_test.go
@@ -191,20 +191,20 @@ func TestConstructIndexEntries(t *testing.T) {
 				IndexDB("db1"): {
 					Writes: []*worldstate.KVWithMetadata{
 						{
-							Key: `{"a":"a1","t":0,"m":"` + PositiveNumber + `","vp":1,"v":"` + encoded10 + `","kp":1,"k":"person1"}`,
+							Key: `{"a":"a1","t":0,"m":"` + PositiveNumber + `","vp":2,"v":"` + encoded10 + `","kp":2,"k":"person1"}`,
 						},
 						{
-							Key: `{"a":"a2","t":1,"m":"","vp":1,"v":"ten","kp":1,"k":"person1"}`,
+							Key: `{"a":"a2","t":1,"m":"","vp":2,"v":"ten","kp":2,"k":"person1"}`,
 						},
 						{
-							Key: `{"a":"a3","t":2,"m":"","vp":1,"v":true,"kp":1,"k":"person1"}`,
+							Key: `{"a":"a3","t":2,"m":"","vp":2,"v":true,"kp":2,"k":"person1"}`,
 						},
 					},
 				},
 				IndexDB("db2"): {
 					Writes: []*worldstate.KVWithMetadata{
 						{
-							Key: `{"a":"a2","t":1,"m":"","vp":1,"v":"eleven","kp":1,"k":"person2"}`,
+							Key: `{"a":"a2","t":1,"m":"","vp":2,"v":"eleven","kp":2,"k":"person2"}`,
 						},
 					},
 				},
@@ -256,25 +256,25 @@ func TestConstructIndexEntries(t *testing.T) {
 				IndexDB("db1"): {
 					Writes: []*worldstate.KVWithMetadata{
 						{
-							Key: `{"a":"a3","t":2,"m":"","vp":1,"v":true,"kp":1,"k":"person1"}`,
+							Key: `{"a":"a3","t":2,"m":"","vp":2,"v":true,"kp":2,"k":"person1"}`,
 						},
 						{
-							Key: `{"a":"a2","t":1,"m":"","vp":1,"v":"10","kp":1,"k":"person1"}`,
+							Key: `{"a":"a2","t":1,"m":"","vp":2,"v":"10","kp":2,"k":"person1"}`,
 						},
 					},
 					Deletes: []string{
-						`{"a":"a3","t":2,"m":"","vp":1,"v":false,"kp":1,"k":"person1"}`,
-						`{"a":"a2","t":1,"m":"","vp":1,"v":"ten","kp":1,"k":"person1"}`,
+						`{"a":"a3","t":2,"m":"","vp":2,"v":false,"kp":2,"k":"person1"}`,
+						`{"a":"a2","t":1,"m":"","vp":2,"v":"ten","kp":2,"k":"person1"}`,
 					},
 				},
 				IndexDB("db2"): {
 					Writes: []*worldstate.KVWithMetadata{
 						{
-							Key: `{"a":"a2","t":1,"m":"","vp":1,"v":"eleven","kp":1,"k":"person2"}`,
+							Key: `{"a":"a2","t":1,"m":"","vp":2,"v":"eleven","kp":2,"k":"person2"}`,
 						},
 					},
 					Deletes: []string{
-						`{"a":"a2","t":1,"m":"","vp":1,"v":"ten","kp":1,"k":"person2"}`,
+						`{"a":"a2","t":1,"m":"","vp":2,"v":"ten","kp":2,"k":"person2"}`,
 					},
 				},
 			},
@@ -314,14 +314,14 @@ func TestConstructIndexEntries(t *testing.T) {
 			expectedIndexEntries: map[string]*worldstate.DBUpdates{
 				IndexDB("db1"): {
 					Deletes: []string{
-						`{"a":"a1","t":0,"m":"` + PositiveNumber + `","vp":1,"v":"` + encoded10 + `","kp":1,"k":"person1"}`,
-						`{"a":"a2","t":1,"m":"","vp":1,"v":"ten","kp":1,"k":"person1"}`,
-						`{"a":"a3","t":2,"m":"","vp":1,"v":true,"kp":1,"k":"person1"}`,
+						`{"a":"a1","t":0,"m":"` + PositiveNumber + `","vp":2,"v":"` + encoded10 + `","kp":2,"k":"person1"}`,
+						`{"a":"a2","t":1,"m":"","vp":2,"v":"ten","kp":2,"k":"person1"}`,
+						`{"a":"a3","t":2,"m":"","vp":2,"v":true,"kp":2,"k":"person1"}`,
 					},
 				},
 				IndexDB("db2"): {
 					Deletes: []string{
-						`{"a":"a2","t":1,"m":"","vp":1,"v":"eleven","kp":1,"k":"person2"}`,
+						`{"a":"a2","t":1,"m":"","vp":2,"v":"eleven","kp":2,"k":"person2"}`,
 					},
 				},
 			},
@@ -736,38 +736,38 @@ func TestRemoveDuplicateIndexEntries(t *testing.T) {
 		{
 			name: "no duplicates",
 			indexOfNewValues: []string{
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
-				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":2,"v":26,"kp":2,"k":"person3"}`,
 			},
 			indexOfExistingValues: []string{
-				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person1"}`,
-				`{"a":"age","t":0,"vp":1,"v":27,"kp":1,"k":"person2"}`,
-				`{"a":"age","t":0,"vp":1,"v":28,"kp":1,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":2,"v":26,"kp":2,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":2,"v":27,"kp":2,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":2,"v":28,"kp":2,"k":"person3"}`,
 			},
 			expectedIndexOfNewValues: []string{
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
-				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":2,"v":26,"kp":2,"k":"person3"}`,
 			},
 			expectedIndexOfExistingValues: []string{
-				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person1"}`,
-				`{"a":"age","t":0,"vp":1,"v":27,"kp":1,"k":"person2"}`,
-				`{"a":"age","t":0,"vp":1,"v":28,"kp":1,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":2,"v":26,"kp":2,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":2,"v":27,"kp":2,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":2,"v":28,"kp":2,"k":"person3"}`,
 			},
 		},
 		{
 			name: "no duplicates as there is no existing value",
 			indexOfNewValues: []string{
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
-				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":2,"v":26,"kp":2,"k":"person3"}`,
 			},
 			indexOfExistingValues: []string{},
 			expectedIndexOfNewValues: []string{
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
-				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":2,"v":26,"kp":2,"k":"person3"}`,
 			},
 			expectedIndexOfExistingValues: []string{},
 		},
@@ -775,47 +775,47 @@ func TestRemoveDuplicateIndexEntries(t *testing.T) {
 			name:             "no duplicates as the new value is empty",
 			indexOfNewValues: []string{},
 			indexOfExistingValues: []string{
-				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person1"}`,
-				`{"a":"age","t":0,"vp":1,"v":27,"kp":1,"k":"person2"}`,
-				`{"a":"age","t":0,"vp":1,"v":28,"kp":1,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":2,"v":26,"kp":2,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":2,"v":27,"kp":2,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":2,"v":28,"kp":2,"k":"person3"}`,
 			},
 			expectedIndexOfNewValues: []string{},
 			expectedIndexOfExistingValues: []string{
-				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person1"}`,
-				`{"a":"age","t":0,"vp":1,"v":27,"kp":1,"k":"person2"}`,
-				`{"a":"age","t":0,"vp":1,"v":28,"kp":1,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":2,"v":26,"kp":2,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":2,"v":27,"kp":2,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":2,"v":28,"kp":2,"k":"person3"}`,
 			},
 		},
 		{
 			name: "two duplicate entries",
 			indexOfNewValues: []string{
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
-				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":2,"v":26,"kp":2,"k":"person3"}`,
 			},
 			indexOfExistingValues: []string{
-				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person1"}`,
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
-				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":2,"v":26,"kp":2,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":2,"v":26,"kp":2,"k":"person3"}`,
 			},
 			expectedIndexOfNewValues: []string{
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person1"}`,
 			},
 			expectedIndexOfExistingValues: []string{
-				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":2,"v":26,"kp":2,"k":"person1"}`,
 			},
 		},
 		{
 			name: "all are duplicate entries",
 			indexOfNewValues: []string{
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
-				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":2,"v":26,"kp":2,"k":"person3"}`,
 			},
 			indexOfExistingValues: []string{
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person1"}`,
-				`{"a":"age","t":0,"vp":1,"v":25,"kp":1,"k":"person2"}`,
-				`{"a":"age","t":0,"vp":1,"v":26,"kp":1,"k":"person3"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person1"}`,
+				`{"a":"age","t":0,"vp":2,"v":25,"kp":2,"k":"person2"}`,
+				`{"a":"age","t":0,"vp":2,"v":26,"kp":2,"k":"person3"}`,
 			},
 			expectedIndexOfNewValues:      []string{},
 			expectedIndexOfExistingValues: []string{},
@@ -840,27 +840,27 @@ func TestLoadIndexEntry(t *testing.T) {
 	}{
 		{
 			name:       "load correctly formatted full entry",
-			indexEntry: []byte(`{"a":"age","t":0,"m":"","vp":1,"v":25,"kp":1,"k":"person1"}`),
+			indexEntry: []byte(`{"a":"age","t":0,"m":"","vp":2,"v":25,"kp":2,"k":"person1"}`),
 			expectedIndexEntry: &IndexEntry{
 				Attribute:     "age",
 				Type:          0,
 				Metadata:      "",
-				ValuePosition: 1,
+				ValuePosition: Existing,
 				Value:         float64(25),
-				KeyPosition:   1,
+				KeyPosition:   Existing,
 				Key:           "person1",
 			},
 		},
 		{
 			name:       "load correctly formatted partial entry",
-			indexEntry: []byte(`{"a":"age","t":0,"m":"","vp":1,"v":25,"kp":1}`),
+			indexEntry: []byte(`{"a":"age","t":0,"m":"","vp":2,"v":25,"kp":2}`),
 			expectedIndexEntry: &IndexEntry{
 				Attribute:     "age",
 				Type:          0,
 				Metadata:      "",
-				ValuePosition: 1,
+				ValuePosition: Existing,
 				Value:         float64(25),
-				KeyPosition:   1,
+				KeyPosition:   Existing,
 				Key:           "",
 			},
 		},
@@ -899,12 +899,12 @@ func TestIndexEntryToString(t *testing.T) {
 				Attribute:     "age",
 				Type:          0,
 				Metadata:      "",
-				ValuePosition: 1,
+				ValuePosition: Existing,
 				Value:         25,
-				KeyPosition:   1,
+				KeyPosition:   Existing,
 				Key:           "person1",
 			},
-			expectedIndexEntry: `{"a":"age","t":0,"m":"","vp":1,"v":25,"kp":1,"k":"person1"}`,
+			expectedIndexEntry: `{"a":"age","t":0,"m":"","vp":2,"v":25,"kp":2,"k":"person1"}`,
 		},
 		{
 			name: "load correctly formatted partial entry",
@@ -912,12 +912,12 @@ func TestIndexEntryToString(t *testing.T) {
 				Attribute:     "age",
 				Type:          0,
 				Metadata:      "",
-				ValuePosition: 1,
+				ValuePosition: Existing,
 				Value:         25,
-				KeyPosition:   1,
+				KeyPosition:   Existing,
 				Key:           "",
 			},
-			expectedIndexEntry: `{"a":"age","t":0,"m":"","vp":1,"v":25,"kp":1,"k":""}`,
+			expectedIndexEntry: `{"a":"age","t":0,"m":"","vp":2,"v":25,"kp":2,"k":""}`,
 		},
 	}
 


### PR DESCRIPTION
As 0 is the default value when we unmarshal or create an index entry object, we could do some mistake or introduce bug in the test code when the enum for certain fields in the object start with 0. Hence, this commit start the index position enum at 1 instead of 0

Signed-off-by: senthil <cendhu@gmail.com>