### PR TITLE
Refactor pending TX queue

### DIFF
--- a/internal/queue/pending_txs.go
+++ b/internal/queue/pending_txs.go
@@ -1,0 +1,61 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package queue
+
+import (
+	"sync"
+
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+)
+
+type PendingTxs struct {
+	txs map[string]*CompletionPromise
+	sync.RWMutex
+}
+
+func NewPendingTxs() *PendingTxs {
+	return &PendingTxs{
+		txs: make(map[string]*CompletionPromise),
+	}
+}
+
+func (p *PendingTxs) Add(txID string, promise *CompletionPromise) {
+	p.Lock()
+	defer p.Unlock()
+
+	p.txs[txID] = promise
+}
+
+// DoneWithReceipt is called after the commit of a block.
+// The `txIDs` slice must be in the same order that transactions appear in the block.
+func (p *PendingTxs) DoneWithReceipt(txIDs []string, blockHeader *types.BlockHeader) {
+	p.Lock()
+	defer p.Unlock()
+
+	for txIndex, txID := range txIDs {
+		p.txs[txID].done(
+			&types.TxReceipt{
+				Header:  blockHeader,
+				TxIndex: uint64(txIndex),
+			},
+		)
+
+		delete(p.txs, txID)
+	}
+}
+
+func (p *PendingTxs) Has(txID string) bool {
+	p.RLock()
+	defer p.RUnlock()
+
+	_, ok := p.txs[txID]
+	return ok
+}
+
+func (p *PendingTxs) Empty() bool {
+	p.RLock()
+	defer p.RUnlock()
+
+	return len(p.txs) == 0
+}

--- a/internal/queue/promise.go
+++ b/internal/queue/promise.go
@@ -1,0 +1,76 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package queue
+
+import (
+	"fmt"
+	"time"
+
+	ierrors "github.com/IBM-Blockchain/bcdb-server/internal/errors"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+)
+
+type CompletionPromise struct {
+	resultCh chan interface{}
+	timeout  time.Duration
+}
+
+func NewCompletionPromise(timeout time.Duration) *CompletionPromise {
+	if timeout <= 0 {
+		return nil
+	}
+
+	return &CompletionPromise{
+		resultCh: make(chan interface{}, 1),
+		timeout:  timeout,
+	}
+}
+
+// Wait is called in order to wait for synchronous transaction completion, rejection, or timeout.
+// When a transaction is committed, a `TxReceipt` is returned.
+// When a transaction is rejected, an error is returned, for example `NotLeaderError`.
+// When wait times out, `TimeoutErr` is returned.
+func (s *CompletionPromise) Wait() (*types.TxReceipt, error) {
+	if s == nil {
+		return nil, nil
+	}
+
+	ticker := time.NewTicker(s.timeout)
+	select {
+	case <-ticker.C:
+		return nil, &ierrors.TimeoutErr{ErrMsg: "timeout has occurred while waiting for the transaction receipt"}
+	case r := <-s.resultCh:
+		ticker.Stop()
+		switch r.(type) {
+		case error:
+			return nil, r.(error)
+		case *types.TxReceipt:
+			return r.(*types.TxReceipt), nil
+		case nil:
+			return nil, &ierrors.ClosedError{ErrMsg: "closed: promise consumed"}
+		default:
+			panic(fmt.Sprintf("unexpected result type: %v", r))
+		}
+	}
+}
+
+// done is called after a transaction commits, and receives the `TxReceipt` as a parameter.
+func (s *CompletionPromise) done(r *types.TxReceipt) {
+	if s == nil {
+		return
+	}
+
+	s.resultCh <- r
+	close(s.resultCh)
+}
+
+// error is called when a transaction is rejected and cannot be committed.
+func (s *CompletionPromise) error(err error) {
+	if s == nil {
+		return
+	}
+
+	s.resultCh <- err
+	close(s.resultCh)
+}

--- a/internal/queue/promise_test.go
+++ b/internal/queue/promise_test.go
@@ -1,0 +1,140 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package queue
+
+import (
+	"testing"
+	"time"
+
+	ierrors "github.com/IBM-Blockchain/bcdb-server/internal/errors"
+	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromise_Done(t *testing.T) {
+	t.Run("As used in sync tx", func(t *testing.T) {
+		promise := NewCompletionPromise(time.Hour)
+
+		go func() {
+			time.Sleep(5 * time.Millisecond)
+			promise.done(
+				&types.TxReceipt{
+					Header:  &types.BlockHeader{},
+					TxIndex: 666,
+				},
+			)
+		}()
+
+		receipt, err := promise.Wait()
+		require.NotNil(t, receipt)
+		require.Equal(t, uint64(666), receipt.TxIndex)
+		require.NoError(t, err)
+
+		checkPromiseAfterCompletion(t, promise)
+	})
+
+	t.Run("Done before Wait", func(t *testing.T) {
+		promise := NewCompletionPromise(time.Hour)
+
+		promise.done(
+			&types.TxReceipt{
+				Header:  &types.BlockHeader{},
+				TxIndex: 666,
+			},
+		)
+		receipt, err := promise.Wait()
+		require.NotNil(t, receipt)
+		require.Equal(t, uint64(666), receipt.TxIndex)
+		require.NoError(t, err)
+
+		checkPromiseAfterCompletion(t, promise)
+	})
+
+}
+
+func checkPromiseAfterCompletion(t *testing.T, promise *CompletionPromise) {
+	require.Panics(t, func() {
+		promise.done(&types.TxReceipt{})
+	})
+
+	require.Panics(t, func() {
+		promise.error(errors.New("oops"))
+	})
+
+	receipt, err := promise.Wait()
+	require.Nil(t, receipt)
+	require.EqualError(t, err, "closed: promise consumed")
+}
+
+func TestPromise_Error(t *testing.T) {
+	t.Run("As used in sync tx", func(t *testing.T) {
+		promise := NewCompletionPromise(time.Hour)
+
+		go func() {
+			time.Sleep(5 * time.Millisecond)
+			promise.error(&ierrors.NotLeaderError{LeaderID: 3})
+		}()
+
+		receipt, err := promise.Wait()
+		require.Nil(t, receipt)
+		require.EqualError(t, err, "not a leader, leader is: 3")
+		require.IsType(t, &ierrors.NotLeaderError{}, err)
+
+		checkPromiseAfterCompletion(t, promise)
+	})
+
+	t.Run("Error before Wait", func(t *testing.T) {
+		promise := NewCompletionPromise(time.Hour)
+
+		promise.error(errors.New("oops"))
+		receipt, err := promise.Wait()
+		require.Nil(t, receipt)
+		require.EqualError(t, err, "oops")
+
+		checkPromiseAfterCompletion(t, promise)
+	})
+}
+
+func TestPromise_Nil(t *testing.T) {
+	// A nil promise is used in an async tx
+	var promise *CompletionPromise
+
+	receipt, err := promise.Wait()
+	require.Nil(t, receipt)
+	require.NoError(t, err)
+	promise.done(&types.TxReceipt{Header: &types.BlockHeader{}, TxIndex: 555})
+	promise.error(errors.New("oops"))
+}
+
+func TestPromise_Timeout(t *testing.T) {
+	t.Run("TO then Done", func(t *testing.T) {
+		promise := NewCompletionPromise(time.Microsecond)
+
+		receipt, err := promise.Wait()
+		require.Nil(t, receipt)
+		require.EqualError(t, err, "timeout has occurred while waiting for the transaction receipt")
+		require.IsType(t, &ierrors.TimeoutErr{}, err)
+
+		promise.done(&types.TxReceipt{Header: &types.BlockHeader{}, TxIndex: 666}) //should not panic
+		receipt, err = promise.Wait()
+		require.NotNil(t, receipt)
+		require.Equal(t, uint64(666), receipt.TxIndex)
+		require.NoError(t, err)
+	})
+
+	t.Run("TO then Error", func(t *testing.T) {
+		promise := NewCompletionPromise(time.Microsecond)
+
+		receipt, err := promise.Wait()
+		require.Nil(t, receipt)
+		require.EqualError(t, err, "timeout has occurred while waiting for the transaction receipt")
+		require.IsType(t, &ierrors.TimeoutErr{}, err)
+
+		promise.error(errors.New("oops")) //should not panic
+		receipt, err = promise.Wait()
+		require.Nil(t, receipt)
+		require.EqualError(t, err, "oops")
+	})
+}


### PR DESCRIPTION
- Fix a bug in the promise were the channel was closed by the receiver, not the sender.
- Add the ability to complete the promise with an error result.
- Refactor the pending txs queue and the promise to the `queue` package.
- Add more unit testing.

Signed-off-by: Yoav Tock <tock@il.ibm.com>