### PR TITLE
test flake in TestBlockReplicator_Submit

### DIFF
--- a/internal/replication/blockreplicator_test.go
+++ b/internal/replication/blockreplicator_test.go
@@ -254,7 +254,7 @@ func TestBlockReplicator_Submit(t *testing.T) {
 				if err != nil {
 					switch err.(type) {
 					case *ierrors.NotLeaderError:
-						require.EqualError(t, err, "not a leader, leader is: 0")
+						require.EqualError(t, err, "not a leader, leader is RaftID: 0, with HostPort: ")
 					case *ierrors.ClosedError:
 						require.EqualError(t, err, "block replicator closed")
 					default:


### PR DESCRIPTION
Address the test flake in TestBlockReplicator_Submit/normal_flow:_blocked_submit
as described in issue #195

Signed-off-by: Yoav Tock <tock@il.ibm.com>