### PR TITLE
Release transactions with error from PendingTxs

### DIFF
--- a/internal/bcdb/transaction_processor.go
+++ b/internal/bcdb/transaction_processor.go
@@ -65,6 +65,7 @@ func newTransactionProcessor(conf *txProcessorConfig) (*transactionProcessor, er
 	p.txQueue = queue.New(localConfig.Server.QueueLength.Transaction)
 	p.txBatchQueue = queue.New(localConfig.Server.QueueLength.ReorderedTransactionBatch)
 	p.blockOneQueueBarrier = queue.NewOneQueueBarrier(conf.logger)
+	p.pendingTxs = queue.NewPendingTxs(conf.logger)
 
 	p.txReorderer = txreorderer.New(
 		&txreorderer.Config{
@@ -113,6 +114,7 @@ func newTransactionProcessor(conf *txProcessorConfig) (*transactionProcessor, er
 			TxBatchQueue: p.txBatchQueue,
 			Logger:       conf.logger,
 			BlockStore:   conf.blockStore,
+			PendingTxs:   p.pendingTxs,
 		},
 	)
 	if err != nil {
@@ -141,6 +143,7 @@ func newTransactionProcessor(conf *txProcessorConfig) (*transactionProcessor, er
 			LedgerReader:         conf.blockStore,
 			Transport:            p.peerTransport,
 			BlockOneQueueBarrier: p.blockOneQueueBarrier,
+			PendingTxs:           p.pendingTxs,
 			Logger:               conf.logger,
 		},
 	)
@@ -170,7 +173,6 @@ func newTransactionProcessor(conf *txProcessorConfig) (*transactionProcessor, er
 	go p.blockProcessor.Start()
 	p.blockProcessor.WaitTillStart()
 
-	p.pendingTxs = queue.NewPendingTxs()
 	p.blockStore = conf.blockStore
 
 	return p, nil

--- a/internal/blockcreator/blockcreator.go
+++ b/internal/blockcreator/blockcreator.go
@@ -23,13 +23,16 @@ type Replicator interface {
 type BlockCreator struct {
 	txBatchQueue                *queue.Queue
 	blockReplicator             Replicator
+	pendingTxs                  *queue.PendingTxs //TODO release blocks rejected from blockReplicator
 	nextBlockNumber             uint64
 	previousBlockHeaderBaseHash []byte
 	blockStore                  *blockstore.Store
-	started                     chan struct{}
-	stop                        chan struct{}
-	stopped                     chan struct{}
-	logger                      *logger.SugarLogger
+
+	started chan struct{}
+	stop    chan struct{}
+	stopped chan struct{}
+
+	logger *logger.SugarLogger
 }
 
 // Config holds the configuration information required to initialize the
@@ -37,6 +40,7 @@ type BlockCreator struct {
 type Config struct {
 	TxBatchQueue *queue.Queue
 	BlockStore   *blockstore.Store
+	PendingTxs   *queue.PendingTxs
 	Logger       *logger.SugarLogger
 }
 
@@ -56,6 +60,7 @@ func New(conf *Config) (*BlockCreator, error) {
 		nextBlockNumber:             height + 1,
 		logger:                      conf.Logger,
 		blockStore:                  conf.BlockStore,
+		pendingTxs:                  conf.PendingTxs,
 		started:                     make(chan struct{}),
 		stop:                        make(chan struct{}),
 		stopped:                     make(chan struct{}),

--- a/internal/blockcreator/blockcreator_test.go
+++ b/internal/blockcreator/blockcreator_test.go
@@ -24,6 +24,7 @@ import (
 type testEnv struct {
 	creator        *blockcreator.BlockCreator
 	txBatchQueue   *queue.Queue
+	pendingTxs     *queue.PendingTxs //TODO test the release of txs
 	blockQueue     *queue.Queue
 	db             worldstate.DB
 	dbPath         string
@@ -73,9 +74,11 @@ func newTestEnv(t *testing.T) *testEnv {
 		t.Fatalf("error while creating the block store, %v", err)
 	}
 
-	txBatchQ := queue.New(10) // Input: transactions
+	txBatchQ := queue.New(10)
+	pendingTxs := queue.NewPendingTxs(logger)
 	b, err := blockcreator.New(&blockcreator.Config{
 		TxBatchQueue: txBatchQ,
+		PendingTxs:   pendingTxs,
 		Logger:       logger,
 		BlockStore:   blockStore,
 	})
@@ -113,6 +116,7 @@ func newTestEnv(t *testing.T) *testEnv {
 		creator:        b,
 		txBatchQueue:   txBatchQ,   // Input
 		blockQueue:     blockQueue, // Output
+		pendingTxs:     pendingTxs, // Output
 		db:             db,
 		dbPath:         dir,
 		blockStore:     blockStore,

--- a/internal/queue/pending_txs.go
+++ b/internal/queue/pending_txs.go
@@ -6,17 +6,21 @@ package queue
 import (
 	"sync"
 
+	"github.com/IBM-Blockchain/bcdb-server/pkg/logger"
 	"github.com/IBM-Blockchain/bcdb-server/pkg/types"
 )
 
 type PendingTxs struct {
-	txs map[string]*CompletionPromise
 	sync.RWMutex
+	txs map[string]*CompletionPromise
+
+	logger *logger.SugarLogger
 }
 
-func NewPendingTxs() *PendingTxs {
+func NewPendingTxs(logger *logger.SugarLogger) *PendingTxs {
 	return &PendingTxs{
-		txs: make(map[string]*CompletionPromise),
+		txs:    make(map[string]*CompletionPromise),
+		logger: logger,
 	}
 }
 
@@ -30,6 +34,8 @@ func (p *PendingTxs) Add(txID string, promise *CompletionPromise) {
 // DoneWithReceipt is called after the commit of a block.
 // The `txIDs` slice must be in the same order that transactions appear in the block.
 func (p *PendingTxs) DoneWithReceipt(txIDs []string, blockHeader *types.BlockHeader) {
+	p.logger.Debugf("Done with receipt, block number: %d; txIDs: %v", blockHeader.GetBaseHeader().GetNumber(), txIDs)
+
 	p.Lock()
 	defer p.Unlock()
 
@@ -40,6 +46,22 @@ func (p *PendingTxs) DoneWithReceipt(txIDs []string, blockHeader *types.BlockHea
 				TxIndex: uint64(txIndex),
 			},
 		)
+
+		delete(p.txs, txID)
+	}
+}
+
+// ReleaseWithError is called when block replication fails with an error, typically NotLeaderError.
+// This may come from the block replicator or the block creator.
+// The `txIDs` slice does not have to be in the same order that transactions appear in the block.
+func (p *PendingTxs) ReleaseWithError(txIDs []string, err error) {
+	p.logger.Debugf("Release with error: %s; txIDs: %v", err, txIDs)
+
+	p.Lock()
+	defer p.Unlock()
+
+	for _, txID := range txIDs {
+		p.txs[txID].error(err)
 
 		delete(p.txs, txID)
 	}

--- a/internal/replication/blockreplicator.go
+++ b/internal/replication/blockreplicator.go
@@ -45,6 +45,7 @@ type BlockReplicator struct {
 	oneQueueBarrier *queue.OneQueueBarrier // Synchronizes the block-replication deliver with the block-processor commit
 	transport       *comm.HTTPTransport
 	ledgerReader    BlockLedgerReader
+	pendingTxs      *queue.PendingTxs //TODO release blocks when not leader or error from Raft on proposal
 
 	stopCh        chan struct{}
 	stopOnce      sync.Once
@@ -75,6 +76,7 @@ type Config struct {
 	LedgerReader         BlockLedgerReader
 	Transport            *comm.HTTPTransport
 	BlockOneQueueBarrier *queue.OneQueueBarrier
+	PendingTxs           *queue.PendingTxs
 	Logger               *logger.SugarLogger
 }
 
@@ -119,6 +121,7 @@ func NewBlockReplicator(conf *Config) (*BlockReplicator, error) {
 		clusterConfig:    conf.ClusterConfig,
 		transport:        conf.Transport,
 		ledgerReader:     conf.LedgerReader,
+		pendingTxs:       conf.PendingTxs,
 		sizeLimit:        conf.ClusterConfig.ConsensusConfig.RaftConfig.SnapshotIntervalSize,
 		confState:        confState,
 		lastSnapBlockNum: snapBlkNum,

--- a/internal/replication/env_test.go
+++ b/internal/replication/env_test.go
@@ -120,6 +120,7 @@ func (n *nodeEnv) Restart() error {
 		},
 	)
 	n.conf.BlockOneQueueBarrier = queue.NewOneQueueBarrier(n.conf.Logger)
+	n.conf.PendingTxs = queue.NewPendingTxs(n.conf.Logger)
 	n.stopServeCh = make(chan struct{})
 	n.blockReplicator, err = replication.NewBlockReplicator(n.conf)
 	if err != nil {
@@ -265,7 +266,7 @@ func newNodeEnv(n uint32, testDir string, lg *logger.SugarLogger, clusterConfig 
 	}
 
 	qBarrier := queue.NewOneQueueBarrier(lg)
-
+	pendingTxs := queue.NewPendingTxs(lg) //TODO test release blocks when not leader or error from Raft on proposal
 	ledger := &memLedger{}
 	proposedBlock := &types.Block{
 		Header: &types.BlockHeader{
@@ -290,6 +291,7 @@ func newNodeEnv(n uint32, testDir string, lg *logger.SugarLogger, clusterConfig 
 		LedgerReader:         ledger,
 		Transport:            peerTransport,
 		BlockOneQueueBarrier: qBarrier,
+		PendingTxs:           pendingTxs,
 		Logger:               lg,
 	}
 


### PR DESCRIPTION
- Add a ReleaseWithError method to PendingTxs queue
- Add a link to PendindTxs queue to block-creator & block-replicator
- Functinality of block-creator & block-replicator in later commits

Signed-off-by: Yoav Tock <tock@il.ibm.com>